### PR TITLE
물약 사용 업적 추가 + attackInfo JSP 장비 화면

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1714,9 +1714,19 @@ public class BossAttackController {
 	        ignore.printStackTrace();
 	    }
 
+	    // 물약 사용 횟수 (캐시 우선, 없으면 DB)
+	    int potionUseCount = 0;
+	    try {
+	        potionUseCount = MiniGameUtil.POTION_USE_CACHE.containsKey(targetUser)
+	                ? MiniGameUtil.POTION_USE_CACHE.get(targetUser)
+	                : botNewService.selectPotionUseCount(targetUser);
+	        MiniGameUtil.POTION_USE_CACHE.putIfAbsent(targetUser, potionUseCount);
+	    } catch (Exception ignore) {}
+
 	    sb.append("누적 전투 기록").append(NL)
 	      .append("- 총 공격 횟수: ").append(totalAttacks).append("회").append(NL)
-	      .append("- 총 사망 횟수: ").append(totalDeaths).append("회").append(NL).append(NL);
+	      .append("- 총 사망 횟수: ").append(totalDeaths).append("회").append(NL)
+	      .append("- 물약 사용 횟수: ").append(potionUseCount).append("회").append(NL).append(NL);
 
 	    if (firstAttackDay != null) {
 	        sb.append("시작일: ")
@@ -2226,7 +2236,21 @@ public class BossAttackController {
 	        botNewService.insertInventoryLogTx(inv);
 	        // 포션 사용
 	        potionMsg = usePotion(ctx, userName, roomName, itemId);
-	    	
+
+	        // 물약 사용 횟수 캐시 갱신 + 업적 즉시 체크
+	        try {
+	            int newPotionCnt = MiniGameUtil.POTION_USE_CACHE.compute(
+	                    userName, (k, v) -> (v == null ? 1 : v + 1));
+	            List<AchievementCount> potionAchvList = botNewService.selectAchvCountsGlobal(userName, roomName);
+	            Set<String> potionAchvSet = new HashSet<>();
+	            if (potionAchvList != null) {
+	                for (AchievementCount ac : potionAchvList) potionAchvSet.add(ac.getCmd());
+	            }
+	            String potionAchvMsg = grantPotionUseAchievements(userName, roomName, potionAchvSet, newPotionCnt);
+	            if (potionAchvMsg != null && !potionAchvMsg.isEmpty()) {
+	                potionMsg = potionMsg + NL + potionAchvMsg;
+	            }
+	        } catch (Exception ignore) {}
 	    }
 	   
 
@@ -3465,8 +3489,10 @@ public class BossAttackController {
 	        HashMap<String,Object> achvInvCounts = null;
 	        try { achvInvCounts = botNewService.selectAchievementInventoryCounts(userName); } catch (Exception ignore) {}
 	        List<HashMap<String,Object>> achvGainRows = buildGainRowsFromCounts(achvInvCounts);
-	        int achvBagTotal  = achvInvCounts != null ? ((Number) achvInvCounts.getOrDefault("BAG_COUNT",  0)).intValue() : 0;
-	        int achvSoldCount = achvInvCounts != null ? ((Number) achvInvCounts.getOrDefault("SOLD_COUNT", 0)).intValue() : 0;
+	        int achvBagTotal   = achvInvCounts != null ? ((Number) achvInvCounts.getOrDefault("BAG_COUNT",   0)).intValue() : 0;
+	        int achvSoldCount  = achvInvCounts != null ? ((Number) achvInvCounts.getOrDefault("SOLD_COUNT",  0)).intValue() : 0;
+	        int achvPotionCount = achvInvCounts != null ? ((Number) achvInvCounts.getOrDefault("POTION_COUNT",0)).intValue() : 0;
+	        MiniGameUtil.POTION_USE_CACHE.put(userName, achvPotionCount);
 
 	        AttackDeathStat achvAds = cachedAds;
 	        List<HashMap<String,Object>> achvJobSkillRows = null;
@@ -3478,8 +3504,9 @@ public class BossAttackController {
 	        String bagAchvMsg     = grantBagAcquireAchievementsFast(userName, roomName, achievedCmdSet, achvBagTotal);   // [PERF] 프리로드
 	        String attackAchvMsg  = grantAttackCountAchievements(userName, roomName, achievedCmdSet, achvAds);           // [PERF] 프리로드
 	        String jobSkillAchvMsg = grantJobSkillUseAchievementsAllJobs(userName, roomName, achievedCmdSet, achvJobSkillRows); // [PERF] 프리로드
-	        String shopSellAchvMsg = grantShopSellAchievementsFast(userName, roomName, achievedCmdSet, achvSoldCount);   // [PERF] 프리로드
-	        
+	        String shopSellAchvMsg  = grantShopSellAchievementsFast(userName, roomName, achievedCmdSet, achvSoldCount);    // [PERF] 프리로드
+	        String potionAchvMsg    = grantPotionUseAchievements(userName, roomName, achievedCmdSet, achvPotionCount);    // [PERF] 프리로드
+
 	        String achvRewardMsg = grantAchievementBasedReward(userName, roomName, userAchvList);
 	        
 	        if ((firstClearMsg   != null && !firstClearMsg.isEmpty())
@@ -3487,9 +3514,10 @@ public class BossAttackController {
 	                || (itemAchvMsg     != null && !itemAchvMsg.isEmpty())
 	                || (attackAchvMsg   != null && !attackAchvMsg.isEmpty())
 	                || (jobSkillAchvMsg != null && !jobSkillAchvMsg.isEmpty())
-	                || (shopSellAchvMsg  != null && !shopSellAchvMsg.isEmpty())
-	                || (achvRewardMsg  != null && !achvRewardMsg.isEmpty())
-	                || (bagAchvMsg   != null && !bagAchvMsg .isEmpty())
+	                || (shopSellAchvMsg != null && !shopSellAchvMsg.isEmpty())
+	                || (potionAchvMsg   != null && !potionAchvMsg.isEmpty())
+	                || (achvRewardMsg   != null && !achvRewardMsg.isEmpty())
+	                || (bagAchvMsg      != null && !bagAchvMsg.isEmpty())
 	        		) {
 
 	                   bonusMsg = NL
@@ -3499,8 +3527,9 @@ public class BossAttackController {
 	                           + attackAchvMsg
 	                           + jobSkillAchvMsg
 	                           + shopSellAchvMsg
+	                           + potionAchvMsg
 	                           + achvRewardMsg
-	                           + bagAchvMsg ;
+	                           + bagAchvMsg;
 	               }
 	    }
 	    bagDropMsg = tryDropBag(userName, roomName, m, nightmare,buff);
@@ -4084,6 +4113,7 @@ public class BossAttackController {
 	    MiniGameUtil.ITEM_DETAIL_CACHE.clear();
 	    MiniGameUtil.ITEM_PRICE_CACHE.clear();
 	    MiniGameUtil.MARKET_OWNED_CACHE.clear();
+	    MiniGameUtil.POTION_USE_CACHE.clear();
 	    initCache();
 	    return "✅ 캐시 갱신 완료" + NL
 	         + "몬스터: " + MiniGameUtil.MONSTER_CACHE.size() + "건" + NL
@@ -4675,6 +4705,55 @@ public class BossAttackController {
 	          .append("회 달성 보상 +")
 	          .append(formatSpShort(rewardSp))
 	          .append(" 지급!♬")
+	          .append(NL);
+	    }
+
+	    return sb.toString();
+	}
+
+	private String grantPotionUseAchievements(
+	        String userName,
+	        String roomName,
+	        Set<String> achvCmdSet,
+	        int potionUseCnt
+	) {
+	    final int[][] rules = {
+	        {10,   1000},
+	        {50,   3000},
+	        {100,  8000},
+	        {300,  15000},
+	        {500,  25000},
+	        {1000, 50000}
+	    };
+
+	    if (potionUseCnt <= 0) return "";
+
+	    StringBuilder sb = new StringBuilder();
+
+	    for (int[] r : rules) {
+	        int threshold = r[0];
+	        int rewardSp  = r[1];
+
+	        if (potionUseCnt < threshold) continue;
+
+	        String cmd = "ACHV_POTION_USE_" + threshold;
+	        if (achvCmdSet.contains(cmd)) continue;
+
+	        HashMap<String,Object> p = new HashMap<>();
+	        p.put("userName", userName);
+	        p.put("roomName", roomName);
+	        p.put("score", rewardSp);
+	        p.put("scoreExt", "");
+	        p.put("cmd", cmd);
+
+	        botNewService.insertPointRank(p);
+	        achvCmdSet.add(cmd);
+
+	        sb.append("✨ 물약 사용 ")
+	          .append(threshold)
+	          .append("회 달성 보상 +")
+	          .append(formatSpShort(rewardSp))
+	          .append(" 지급!")
 	          .append(NL);
 	    }
 

--- a/src/main/java/my/prac/api/loa/controller/LoaUserInfoViewController.java
+++ b/src/main/java/my/prac/api/loa/controller/LoaUserInfoViewController.java
@@ -1,0 +1,108 @@
+package my.prac.api.loa.controller;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.Resource;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import my.prac.core.prjbot.service.BotNewService;
+import my.prac.core.util.MiniGameUtil;
+
+@Controller
+@RequestMapping("/loa")
+public class LoaUserInfoViewController {
+
+    @Resource(name = "core.prjbot.BotNewService")
+    BotNewService botNewService;
+
+    /** JSP 뷰 페이지 */
+    @GetMapping("/user-info-view")
+    public String userInfoViewPage() {
+        return "nonsession/loa/user_info_view";
+    }
+
+    /**
+     * REST API: 유저 정보 (장비 화면용)
+     * - user: 기본 스탯 (lv, job, hp, atk, crit, regen ...)
+     * - inventory: 전체 인벤토리 목록 (itemId, itemName, qty, 스탯)
+     * - potionUseCount: 물약 사용 횟수
+     */
+    @GetMapping("/api/user-info")
+    @ResponseBody
+    public ResponseEntity<?> getUserInfo(
+            @RequestParam(value = "userName", defaultValue = "") String userName) {
+
+        HashMap<String, Object> result = new HashMap<>();
+
+        if (userName.trim().isEmpty()) {
+            result.put("error", "유저명을 입력하세요.");
+            return ResponseEntity.ok(result);
+        }
+
+        // 1) 인벤토리
+        List<HashMap<String, Object>> inventory = new ArrayList<>();
+        try {
+            List<HashMap<String, Object>> raw = botNewService.selectInventorySummaryAll(userName, "");
+            if (raw != null) {
+                for (HashMap<String, Object> row : raw) {
+                    int itemId = toInt(row.get("ITEM_ID"));
+                    // 포션류 제외 (1001~1006)
+                    if (itemId >= 1001 && itemId <= 1006) continue;
+                    inventory.add(row);
+                }
+            }
+        } catch (Exception ignore) {}
+
+        // 2) 물약 사용 횟수 (캐시 우선)
+        int potionUseCount = 0;
+        try {
+            potionUseCount = MiniGameUtil.POTION_USE_CACHE.containsKey(userName)
+                    ? MiniGameUtil.POTION_USE_CACHE.get(userName)
+                    : botNewService.selectPotionUseCount(userName);
+            MiniGameUtil.POTION_USE_CACHE.putIfAbsent(userName, potionUseCount);
+        } catch (Exception ignore) {}
+
+        // 3) 아이템 카테고리 레이블 주입
+        for (HashMap<String, Object> item : inventory) {
+            int id = toInt(item.get("ITEM_ID"));
+            item.put("_category", resolveCategory(id));
+        }
+
+        result.put("inventory", inventory);
+        result.put("potionUseCount", potionUseCount);
+        result.put("userName", userName);
+
+        return ResponseEntity.ok(result);
+    }
+
+    private String resolveCategory(int id) {
+        if (id >= 100 && id < 200)  return "무기";
+        if (id >= 200 && id < 300)  return "투구";
+        if (id >= 300 && id < 400)  return "행운";
+        if (id >= 400 && id < 500)  return "갑옷";
+        if (id >= 500 && id < 600)  return "반지";
+        if (id >= 600 && id < 700)  return "토템";
+        if (id >= 700 && id < 800)  return "전설";
+        if (id >= 800 && id < 900)  return "날개";
+        if (id >= 900 && id < 1000) return "선물";
+        if (id >= 8000 && id < 9000) return "업적";
+        if (id >= 9000)              return "유물";
+        return "기타";
+    }
+
+    private int toInt(Object o) {
+        if (o == null) return 0;
+        try { return Integer.parseInt(Objects.toString(o, "0")); }
+        catch (Exception e) { return 0; }
+    }
+}

--- a/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
@@ -198,6 +198,9 @@ public interface BotNewDAO {
     // [OPT3] INVENTORY 3개 쿼리 통합
     HashMap<String,Object> selectAchievementInventoryCounts(@Param("userName") String userName);
 
+    /** 물약 사용 횟수 조회 */
+    int selectPotionUseCount(@Param("userName") String userName);
+
     List<String> selectRandomBlessTargets(HashMap<String, Object> map);
 
     int updateBlessYn(String userName);

--- a/src/main/java/my/prac/core/prjbot/service/BotNewService.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotNewService.java
@@ -157,6 +157,9 @@ public interface BotNewService {
 
     // [OPT3] INVENTORY 3개 쿼리 통합
     HashMap<String,Object> selectAchievementInventoryCounts(String userName);
+
+    /** 물약 사용 횟수 조회 */
+    int selectPotionUseCount(String userName);
     
     public int updateRandomBlessUser(String attacker,int count) ;
     public void clearBlessYn(String userName) ;

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
@@ -486,6 +486,11 @@ public class BotNewServiceImpl implements BotNewService {
         return botNewDAO.selectAchievementInventoryCounts(userName);
     }
 
+    @Override
+    public int selectPotionUseCount(String userName) {
+        return botNewDAO.selectPotionUseCount(userName);
+    }
+
     public int updateRandomBlessUser(String attacker,int count) {
     	HashMap<String,Object> param = new HashMap<>();
         param.put("attacker", attacker);

--- a/src/main/java/my/prac/core/util/MiniGameUtil.java
+++ b/src/main/java/my/prac/core/util/MiniGameUtil.java
@@ -64,6 +64,9 @@ public class MiniGameUtil {
 
 	// 데일리버프 캐시 (yyyyMMdd|userName → HashMap, 일 단위 자동만료)
 	public static final ConcurrentHashMap<String, HashMap<String,Object>> DAILY_BUFF_CACHE = new ConcurrentHashMap<>();
+
+	// 물약 사용 횟수 캐시 (userName → 총 사용 횟수)
+	public static final ConcurrentHashMap<String, Integer> POTION_USE_CACHE = new ConcurrentHashMap<>();
 	// ─────────────────────────────────────────────────────────────────────────
 
 	static {

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -1539,9 +1539,18 @@
 	        NVL(SUM(CASE WHEN GAIN_TYPE='DROP9'  THEN QTY ELSE 0 END), 0) AS DROP9_QTY,
 	        NVL(SUM(CASE WHEN ITEM_ID IN (91,92,93) THEN QTY ELSE 0 END), 0) AS BAG_COUNT,
 	        NVL(SUM(CASE WHEN GAIN_TYPE IN ('DROP','DROP3','DROP5','DROP9','STEAL')
-	                          AND NVL(DEL_YN,'0')='1' THEN QTY ELSE 0 END), 0) AS SOLD_COUNT
+	                          AND NVL(DEL_YN,'0')='1' THEN QTY ELSE 0 END), 0) AS SOLD_COUNT,
+	        NVL(SUM(CASE WHEN ITEM_ID BETWEEN 1001 AND 1006 THEN 1 ELSE 0 END), 0) AS POTION_COUNT
 	    FROM TBOT_POINT_NEW_INVENTORY
 	    WHERE USER_NAME = #{userName}
+	</select>
+
+	<select id="selectPotionUseCount" resultType="int">
+	    /* selectPotionUseCount */
+	    SELECT NVL(COUNT(*), 0)
+	    FROM TBOT_POINT_NEW_INVENTORY
+	    WHERE USER_NAME = #{userName}
+	      AND ITEM_ID BETWEEN 1001 AND 1006
 	</select>
 
 	<select id="selectRandomBlessTargets" parameterType="map" resultType="string">

--- a/src/main/webapp/WEB-INF/view/nonsession/loa/user_info_view.jsp
+++ b/src/main/webapp/WEB-INF/view/nonsession/loa/user_info_view.jsp
@@ -1,0 +1,375 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" isELIgnored="true"%>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>람쥐봇 장비 정보</title>
+  <link rel="stylesheet" href="<%=request.getContextPath()%>/assets/css/font-awesome.min.css">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: #1a1a2e; font-family: 'Segoe UI', 'Malgun Gothic', sans-serif; color: #e0e0e0; min-height: 100vh; }
+
+    .wrap { max-width: 900px; margin: 0 auto; padding: 20px 12px 60px; }
+
+    /* 헤더 */
+    .page-header { margin-bottom: 18px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+    .page-title  { font-size: 20px; font-weight: 800; color: #a8c0ff; }
+    .search-row  { display: flex; gap: 8px; }
+    .search-row input { padding: 8px 14px; border: 1.5px solid #3a3a6a; border-radius: 20px; background: #16213e; color: #e0e0e0; font-size: 13px; width: 160px; outline: none; }
+    .search-row input:focus { border-color: #a8c0ff; }
+    .btn-search  { background: #4a6fa5; color: #fff; border: none; padding: 8px 18px; border-radius: 20px; font-size: 13px; font-weight: 700; cursor: pointer; }
+    .btn-search:hover { background: #3a5f95; }
+
+    .loading { text-align: center; padding: 60px; color: #666; font-size: 15px; }
+    .empty   { text-align: center; padding: 60px; color: #555; }
+
+    /* ── 장비 화면 레이아웃 ── */
+    .equip-screen { display: grid; grid-template-columns: 140px 1fr 140px; gap: 10px; min-height: 420px; }
+
+    /* 좌우 슬롯 패널 */
+    .slot-col { display: flex; flex-direction: column; gap: 8px; }
+
+    /* 캐릭터 중앙 영역 */
+    .char-area { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+    .char-box  { background: #0f3460; border: 2px solid #4a6fa5; border-radius: 16px; width: 160px; height: 220px; display: flex; align-items: center; justify-content: center; font-size: 72px; flex-shrink: 0; }
+    .char-name { font-size: 14px; font-weight: 800; color: #a8c0ff; text-align: center; }
+    .char-job  { font-size: 12px; color: #7fa8d4; text-align: center; }
+    .char-lv   { font-size: 20px; font-weight: 900; color: #ffd700; text-align: center; }
+
+    /* 상단/하단 슬롯 (가로 배치) */
+    .slot-row  { display: flex; gap: 8px; justify-content: center; }
+
+    /* 개별 슬롯 */
+    .slot {
+      background: #16213e;
+      border: 1.5px solid #2a2a5a;
+      border-radius: 12px;
+      padding: 8px 10px;
+      min-height: 68px;
+      cursor: default;
+      transition: border-color .2s, background .2s;
+      position: relative;
+    }
+    .slot.has-item { border-color: #4a6fa5; cursor: pointer; }
+    .slot.has-item:hover { background: #1e2f5a; border-color: #a8c0ff; }
+    .slot.slot-sm { min-height: 56px; }
+
+    /* 특별 아이템 (100,200,400,700,800): 금테 */
+    .slot.special-item { border-color: #c9a96e; }
+    .slot.special-item:hover { background: #1e1a10; border-color: #ffd700; }
+
+    .slot-label { font-size: 9px; color: #556; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 2px; }
+    .slot-icon  { font-size: 20px; line-height: 1; }
+    .slot-name  { font-size: 10px; color: #9ab; margin-top: 3px; line-height: 1.3; }
+    .slot-qty   { font-size: 9px; color: #ffd700; margin-top: 2px; }
+    .slot-empty { font-size: 11px; color: #333; margin-top: 4px; }
+
+    /* 합계 칸 (행운/반지/토템/선물) */
+    .summary-row { display: flex; gap: 6px; flex-wrap: wrap; justify-content: center; margin-top: 6px; }
+    .sum-chip { background: #16213e; border: 1px solid #2a2a5a; border-radius: 8px; padding: 4px 10px; font-size: 11px; color: #9ab; }
+    .sum-chip strong { color: #ffd700; margin-left: 3px; }
+
+    /* 포션 사용 뱃지 */
+    .potion-badge { background: #0f3460; border: 1px solid #4a6fa5; border-radius: 8px; padding: 4px 12px; font-size: 11px; color: #a8c0ff; text-align: center; margin-top: 4px; }
+
+    /* ── 툴팁/모달 ── */
+    .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.6); z-index: 100; display: flex; align-items: center; justify-content: center; }
+    .modal-box { background: #0f3460; border: 2px solid #c9a96e; border-radius: 16px; padding: 20px 22px; min-width: 240px; max-width: 320px; box-shadow: 0 8px 32px rgba(0,0,0,.5); position: relative; }
+    .modal-close { position: absolute; top: 10px; right: 14px; font-size: 18px; color: #888; cursor: pointer; line-height: 1; }
+    .modal-close:hover { color: #fff; }
+    .modal-title { font-size: 15px; font-weight: 800; color: #ffd700; margin-bottom: 12px; }
+    .modal-stat  { display: flex; justify-content: space-between; font-size: 12px; padding: 4px 0; border-bottom: 1px solid #1a2a4a; }
+    .modal-stat:last-child { border-bottom: none; }
+    .modal-stat .lbl { color: #9ab; }
+    .modal-stat .val { color: #a8e6cf; font-weight: 700; }
+
+    /* 하단 기타 아이템 목록 */
+    .others-section { margin-top: 14px; }
+    .others-title { font-size: 12px; color: #556; margin-bottom: 8px; font-weight: 700; }
+    .others-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 6px; }
+    .other-chip { background: #16213e; border: 1px solid #2a2a5a; border-radius: 8px; padding: 6px 10px; font-size: 11px; color: #9ab; }
+    .other-chip .o-name { color: #c0c0c0; font-weight: 600; }
+    .other-chip .o-qty  { color: #ffd700; margin-left: 4px; }
+
+    @media (max-width: 600px) {
+      .equip-screen { grid-template-columns: 110px 1fr 110px; gap: 6px; }
+      .char-box { width: 120px; height: 170px; font-size: 54px; }
+    }
+  </style>
+</head>
+<body>
+<div id="app" class="wrap">
+
+  <div class="page-header">
+    <div class="page-title">⚔ 람쥐봇 장비 정보</div>
+    <div class="search-row">
+      <input v-model="inputUser" placeholder="유저명 입력" @keyup.enter="fetchInfo">
+      <button class="btn-search" @click="fetchInfo">조회</button>
+    </div>
+  </div>
+
+  <div class="loading" v-if="loading"><i class="fa fa-spinner fa-spin"></i> 불러오는 중...</div>
+  <div class="empty" v-else-if="!userName">유저명을 입력해 조회하세요.</div>
+
+  <template v-else>
+    <!-- ── 장비 화면 ── -->
+    <div class="equip-screen">
+
+      <!-- 좌측 슬롯: 무기, 갑옷 -->
+      <div class="slot-col">
+        <div v-for="slot in leftSlots" :key="slot.cat"
+             class="slot" :class="slotClass(slot)"
+             @click="openModal(slot)">
+          <div class="slot-label">{{ slot.cat }}</div>
+          <template v-if="slot.item">
+            <div class="slot-icon">{{ catIcon(slot.cat) }}</div>
+            <div class="slot-name">{{ slot.item.ITEM_NAME }}</div>
+            <div class="slot-qty" v-if="slot.item.TOTAL_QTY > 1">×{{ slot.item.TOTAL_QTY }}</div>
+          </template>
+          <div class="slot-empty" v-else>-</div>
+        </div>
+      </div>
+
+      <!-- 중앙: 캐릭터 + 상/하 슬롯 -->
+      <div class="char-area">
+        <!-- 상단: 투구 -->
+        <div class="slot-row">
+          <div v-for="slot in topSlots" :key="slot.cat"
+               class="slot slot-sm" :class="slotClass(slot)"
+               @click="openModal(slot)">
+            <div class="slot-label">{{ slot.cat }}</div>
+            <template v-if="slot.item">
+              <div class="slot-icon">{{ catIcon(slot.cat) }}</div>
+              <div class="slot-name">{{ slot.item.ITEM_NAME }}</div>
+            </template>
+            <div class="slot-empty" v-else>-</div>
+          </div>
+        </div>
+
+        <!-- 캐릭터 -->
+        <div class="char-box">🧙</div>
+        <div class="char-lv">Lv {{ userName }}</div>
+        <div class="char-name">{{ userName }}</div>
+
+        <!-- 하단: 날개 -->
+        <div class="slot-row">
+          <div v-for="slot in bottomSlots" :key="slot.cat"
+               class="slot slot-sm" :class="slotClass(slot)"
+               @click="openModal(slot)">
+            <div class="slot-label">{{ slot.cat }}</div>
+            <template v-if="slot.item">
+              <div class="slot-icon">{{ catIcon(slot.cat) }}</div>
+              <div class="slot-name">{{ slot.item.ITEM_NAME }}</div>
+            </template>
+            <div class="slot-empty" v-else>-</div>
+          </div>
+        </div>
+
+        <!-- 합계 요약 (행운/반지/토템/선물) -->
+        <div class="summary-row">
+          <div class="sum-chip" v-for="g in groupSummary" :key="g.label">
+            {{ g.label }} <strong>{{ g.total }}</strong>
+          </div>
+        </div>
+        <!-- 물약 사용 -->
+        <div class="potion-badge">🧪 물약 사용: {{ potionUseCount }}회</div>
+      </div>
+
+      <!-- 우측 슬롯: 전설, 유물 -->
+      <div class="slot-col">
+        <div v-for="slot in rightSlots" :key="slot.cat"
+             class="slot" :class="slotClass(slot)"
+             @click="openModal(slot)">
+          <div class="slot-label">{{ slot.cat }}</div>
+          <template v-if="slot.item">
+            <div class="slot-icon">{{ catIcon(slot.cat) }}</div>
+            <div class="slot-name">{{ slot.item.ITEM_NAME }}</div>
+          </template>
+          <div class="slot-empty" v-else>-</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 기타 아이템 (업적 등) -->
+    <div class="others-section" v-if="otherItems.length > 0">
+      <div class="others-title">기타 아이템</div>
+      <div class="others-grid">
+        <div class="other-chip" v-for="it in otherItems" :key="it.ITEM_ID">
+          <span class="o-name">{{ it.ITEM_NAME }}</span>
+          <span class="o-qty">×{{ it.TOTAL_QTY }}</span>
+        </div>
+      </div>
+    </div>
+  </template>
+
+  <!-- ── 모달 ── -->
+  <div class="modal-overlay" v-if="modal" @click.self="modal=null">
+    <div class="modal-box">
+      <span class="modal-close" @click="modal=null">✕</span>
+      <div class="modal-title">{{ catIcon(modal.cat) }} {{ modal.item ? modal.item.ITEM_NAME : modal.cat }}</div>
+      <template v-if="modal.item">
+        <div class="modal-stat" v-for="s in itemStats(modal.item)" :key="s.lbl">
+          <span class="lbl">{{ s.lbl }}</span>
+          <span class="val">{{ s.val }}</span>
+        </div>
+        <div class="modal-stat">
+          <span class="lbl">보유 수량</span>
+          <span class="val">{{ modal.item.TOTAL_QTY }}</span>
+        </div>
+      </template>
+      <div v-else style="color:#666;font-size:13px;margin-top:8px;">장착된 아이템 없음</div>
+    </div>
+  </div>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js"></script>
+<script>
+// 옵션 표시할 특정 아이템 ID 목록
+var OPTION_ITEM_IDS = [100, 200, 400, 700, 800];
+
+// 슬롯 정의: cat → ITEM_ID 범위
+var SLOT_DEFS = {
+  '무기': { min: 100, max: 200 },
+  '투구': { min: 200, max: 300 },
+  '갑옷': { min: 400, max: 500 },
+  '전설': { min: 700, max: 800 },
+  '날개': { min: 800, max: 900 },
+  '유물': { min: 9000, max: 99999 }
+};
+
+// 합계 표시 범위
+var GROUP_DEFS = [
+  { label: '행운', min: 300, max: 400 },
+  { label: '반지', min: 500, max: 600 },
+  { label: '토템', min: 600, max: 700 },
+  { label: '선물', min: 900, max: 1000 }
+];
+
+var CAT_ICONS = {
+  '무기': '⚔️', '투구': '🪖', '갑옷': '🛡️', '전설': '✨', '날개': '🪽',
+  '유물': '🏺', '업적': '🏆', '행운': '🍀', '반지': '💍', '토템': '🗿', '선물': '🎁', '기타': '📦'
+};
+
+new Vue({
+  el: '#app',
+  data: {
+    inputUser: '',
+    userName: '',
+    loading: false,
+    inventory: [],
+    potionUseCount: 0,
+    modal: null
+  },
+  computed: {
+    // 슬롯별 대표 아이템 (보유 중 첫 번째)
+    slotMap() {
+      var map = {};
+      Object.keys(SLOT_DEFS).forEach(function(cat) {
+        map[cat] = null;
+      });
+      this.inventory.forEach(function(it) {
+        var id = +it.ITEM_ID;
+        Object.keys(SLOT_DEFS).forEach(function(cat) {
+          var def = SLOT_DEFS[cat];
+          if (id >= def.min && id < def.max) {
+            if (!map[cat]) map[cat] = it;
+          }
+        });
+      });
+      return map;
+    },
+    leftSlots()   { return [this.mkSlot('무기'), this.mkSlot('갑옷')]; },
+    topSlots()    { return [this.mkSlot('투구')]; },
+    bottomSlots() { return [this.mkSlot('날개')]; },
+    rightSlots()  { return [this.mkSlot('전설'), this.mkSlot('유물')]; },
+
+    groupSummary() {
+      var inv = this.inventory;
+      return GROUP_DEFS.map(function(g) {
+        var total = 0;
+        inv.forEach(function(it) {
+          var id = +it.ITEM_ID;
+          if (id >= g.min && id < g.max) total += (+it.TOTAL_QTY || 0);
+        });
+        return { label: g.label, total: total };
+      }).filter(function(g) { return g.total > 0; });
+    },
+
+    // 슬롯에 안 들어간 나머지 (업적 등)
+    otherItems() {
+      var mainIds = new Set();
+      var inv = this.inventory;
+      inv.forEach(function(it) {
+        var id = +it.ITEM_ID;
+        var inMain = false;
+        Object.keys(SLOT_DEFS).forEach(function(cat) {
+          var def = SLOT_DEFS[cat];
+          if (id >= def.min && id < def.max) inMain = true;
+        });
+        GROUP_DEFS.forEach(function(g) {
+          if (id >= g.min && id < g.max) inMain = true;
+        });
+        if (!inMain) mainIds.add(id);
+      });
+      return inv.filter(function(it) { return mainIds.has(+it.ITEM_ID); });
+    }
+  },
+  methods: {
+    mkSlot(cat) { return { cat: cat, item: this.slotMap[cat] || null }; },
+    catIcon(cat) { return CAT_ICONS[cat] || '📦'; },
+
+    slotClass(slot) {
+      if (!slot.item) return {};
+      var id = +slot.item.ITEM_ID;
+      return {
+        'has-item': true,
+        'special-item': OPTION_ITEM_IDS.indexOf(id) !== -1
+      };
+    },
+
+    openModal(slot) {
+      if (!slot.item) return;
+      this.modal = slot;
+    },
+
+    itemStats(item) {
+      var stats = [];
+      var add = function(lbl, key) {
+        var v = +item[key];
+        if (v && v !== 0) stats.push({ lbl: lbl, val: v });
+      };
+      add('공격력 최소', 'ATK_MIN');
+      add('공격력 최대', 'ATK_MAX');
+      add('치명타율', 'ATK_CRI');
+      add('치명타 피해', 'CRI_DMG');
+      add('최대 체력', 'HP_MAX');
+      add('HP 비율', 'HP_MAX_RATE');
+      add('ATK 비율', 'ATK_MAX_RATE');
+      add('체력 회복', 'HP_REGEN');
+      return stats;
+    },
+
+    fetchInfo() {
+      var name = this.inputUser.trim();
+      if (!name) return;
+      this.loading = true;
+      this.inventory = [];
+      this.modal = null;
+      var self = this;
+      fetch('<%=request.getContextPath()%>/loa/api/user-info?userName=' + encodeURIComponent(name))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          self.userName = data.userName || name;
+          self.inventory = data.inventory || [];
+          self.potionUseCount = data.potionUseCount || 0;
+          self.loading = false;
+        })
+        .catch(function() { self.loading = false; });
+    }
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
[물약 업적]
- selectAchievementInventoryCounts에 POTION_COUNT 컬럼 추가
- selectPotionUseCount 독립 쿼리 추가 (DAO/Service/Impl)
- MiniGameUtil.POTION_USE_CACHE 추가 (/갱신 시 초기화)
- grantPotionUseAchievements: 10/50/100/300/500/1000회 임계치
- 포션 구매 즉시 업적 체크 + monsterAttack kill 시 재체크
- attackInfo 누적 전투 기록에 물약 사용 횟수 표시

[장비 화면 JSP]
- LoaUserInfoViewController: /loa/user-info-view, /loa/api/user-info
- user_info_view.jsp: Vue.js 장비 화면 (RPG 스타일)
  - 무기/투구/갑옷/전설/날개/유물 슬롯 배치
  - 아이템 100,200,400,700,800은 금테 + 클릭 시 옵션 모달
  - 행운/반지/토템/선물은 합계 chip으로 표시
  - 물약 사용 횟수 뱃지 표시