### PR TITLE
fix: 헌터랭크/업적 뷰 무한 스피너 + CMD 패턴 불일치 수정

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/LoaAchievementViewController.java
+++ b/src/main/java/my/prac/api/loa/controller/LoaAchievementViewController.java
@@ -84,9 +84,9 @@ public class LoaAchievementViewController {
             if (v instanceof Number) {
                 int qty = ((Number) v).intValue();
                 totalDrops += qty;
-                if ("DROP3".equals(type)) lightQty = qty;
-                else if ("DROP5".equals(type)) darkQty = qty;
-                else if ("DROP9".equals(type)) grayQty = qty;
+                if (AchievementConfig.ITEM_TYPE_LIGHT.equals(type)) lightQty += qty; // DROP3
+                else if (AchievementConfig.ITEM_TYPE_DARK.equals(type)) darkQty += qty;  // DROP5
+                else if (AchievementConfig.ITEM_TYPE_GRAY.equals(type)) grayQty += qty;  // DROP9
             }
         }
 
@@ -144,12 +144,12 @@ public class LoaAchievementViewController {
         Pattern P_MON_KILL     = Pattern.compile("^ACHV_KILL_MON_(\\d+)_(\\d+)$");
         Pattern P_DEATH        = Pattern.compile("^ACHV_DEATH_(\\d+)$");
         Pattern P_ATTACK       = Pattern.compile("^ACHV_ATTACK_TOTAL_(\\d+)$");
-        Pattern P_LIGHT        = Pattern.compile("^ACHV_ITEM_DROP3_(\\d+)$");
-        Pattern P_DARK         = Pattern.compile("^ACHV_ITEM_DROP5_(\\d+)$");
-        Pattern P_GRAY         = Pattern.compile("^ACHV_ITEM_DROP9_(\\d+)$");
-        Pattern P_SKILL        = Pattern.compile("^ACHV_SKILL_(.+)_(\\d+)$");
-        Pattern P_SELL         = Pattern.compile("^ACHV_SELL_(\\d+)$");
-        Pattern P_POTION       = Pattern.compile("^ACHV_POTION_(\\d+)$");
+        Pattern P_LIGHT        = Pattern.compile("^ACHV_LIGHT_ITEM_(\\d+)$");
+        Pattern P_DARK         = Pattern.compile("^ACHV_DARK_ITEM_(\\d+)$");
+        Pattern P_GRAY         = Pattern.compile("^ACHV_GRAY_ITEM_(\\d+)$");
+        Pattern P_SKILL        = Pattern.compile("^ACHV_JOB_SKILL_(.+)_(\\d+)$");
+        Pattern P_SELL         = Pattern.compile("^ACHV_SHOP_SELL_(\\d+)$");
+        Pattern P_POTION       = Pattern.compile("^ACHV_POTION_USE_(\\d+)$");
         Pattern P_BAG          = Pattern.compile("^ACHV_BAG_(\\d+)$");
         Pattern P_HELL_ATK     = Pattern.compile("^ACHV_HELL_ATK_(\\d+)$");
         Pattern P_HELL_CLEAR   = Pattern.compile("^ACHV_HELL_CLEAR_(\\d+)$");

--- a/src/main/webapp/WEB-INF/view/nonsession/loa/achievement_view.jsp
+++ b/src/main/webapp/WEB-INF/view/nonsession/loa/achievement_view.jsp
@@ -63,8 +63,8 @@
   <div class="page-header">
     <div class="page-title">🏆 람쥐봇 업적</div>
     <div class="search-row">
-      <input v-model="inputUser" placeholder="유저명 입력" @keyup.enter="fetch">
-      <button class="btn-search" @click="fetch">조회</button>
+      <input v-model="inputUser" placeholder="유저명 입력" @keyup.enter="loadData">
+      <button class="btn-search" @click="loadData">조회</button>
     </div>
   </div>
 
@@ -281,19 +281,20 @@ new Vue({
   mounted() {
     var p = new URLSearchParams(window.location.search);
     var u = p.get('userName') || p.get('user') || sessionStorage.getItem('loaUserName') || '';
-    if (u) { this.inputUser = u; this.fetch(); }
+    if (u) { this.inputUser = u; this.loadData(); }
   },
   methods: {
-    fetch() {
+    loadData() {
       var u = this.inputUser.trim();
       if (!u) return;
       this.userName = u;
       sessionStorage.setItem('loaUserName', u);
       this.loading = true;
+      var self = this;
       fetch('<%=request.getContextPath()%>/loa/api/achievements?userName=' + encodeURIComponent(u))
-        .then(r => r.json())
-        .then(d => { this.data = d; this.loading = false; })
-        .catch(() => { this.loading = false; });
+        .then(function(r) { return r.json(); })
+        .then(function(d) { self.data = d; self.loading = false; })
+        .catch(function() { self.loading = false; });
     },
     fmt(n) { return (n || 0).toLocaleString('ko-KR'); }
   }

--- a/src/main/webapp/WEB-INF/view/nonsession/loa/hunter_rank_view.jsp
+++ b/src/main/webapp/WEB-INF/view/nonsession/loa/hunter_rank_view.jsp
@@ -87,8 +87,8 @@
   <div class="page-header">
     <div class="page-title">🎯 헌터 랭크 달성율</div>
     <div class="search-row">
-      <input v-model="inputUser" placeholder="유저명 입력" @keyup.enter="fetch">
-      <button class="btn-search" @click="fetch">조회</button>
+      <input v-model="inputUser" placeholder="유저명 입력" @keyup.enter="loadData">
+      <button class="btn-search" @click="loadData">조회</button>
     </div>
   </div>
 
@@ -276,19 +276,20 @@ new Vue({
   mounted() {
     var p = new URLSearchParams(window.location.search);
     var u = p.get('userName') || p.get('user') || sessionStorage.getItem('loaUserName') || '';
-    if (u) { this.inputUser = u; this.fetch(); }
+    if (u) { this.inputUser = u; this.loadData(); }
   },
   methods: {
-    fetch() {
+    loadData() {
       var u = this.inputUser.trim();
       if (!u) return;
       this.userName = u;
       sessionStorage.setItem('loaUserName', u);
       this.loading = true;
+      var self = this;
       fetch('<%=request.getContextPath()%>/loa/api/hunter-rank?userName=' + encodeURIComponent(u))
-        .then(r => r.json())
-        .then(d => { this.data = d; this.loading = false; })
-        .catch(() => { this.loading = false; });
+        .then(function(r) { return r.json(); })
+        .then(function(d) { self.data = d; self.loading = false; })
+        .catch(function() { self.loading = false; });
     },
     fmt(n) { return (n || 0).toLocaleString('ko-KR'); },
     pct(v, max) { return max > 0 ? Math.round(v / max * 1000) / 10 : 0; }


### PR DESCRIPTION
- Vue 메서드명 fetch→loadData: window.fetch와 이름 충돌로 인한 무한재귀 방지 (기존 user_info_view.jsp 패턴 fetchInfo와 동일하게 맞춤)
- 화살표함수 → function+self 패턴으로 변경 (vue.min.js 호환성)
- LoaAchievementViewController CMD 패턴 실제 DB값으로 수정: ACHV_ITEM_DROP3 → ACHV_LIGHT_ITEM ACHV_ITEM_DROP5 → ACHV_DARK_ITEM ACHV_ITEM_DROP9 → ACHV_GRAY_ITEM ACHV_SELL → ACHV_SHOP_SELL ACHV_POTION → ACHV_POTION_USE ACHV_SKILL → ACHV_JOB_SKILL