### PR TITLE
fix: GP/보스뽑기 컴파일 오류 수정 - DAO/ServiceImpl 누락 구현 추가

### DIFF
--- a/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
@@ -201,6 +201,9 @@ public interface BotNewDAO {
     HashMap<String,Object> selectHellUnlockStats(@Param("userName") String userName);
     HashMap<String,Object> selectHeavenItemBuff(@Param("userName") String userName);
     List<Integer> selectItemIdsByType(@Param("itemType") String itemType);
+    List<HashMap<String, Object>> selectHellRewardItemsWithOwnCount();
+    void insertGpRecord(HashMap<String, Object> param);
+    int selectGpBalance(@Param("userName") String userName);
 
     void lockMacroUser(HashMap<String, Object> map);
     

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
@@ -529,6 +529,26 @@ public class BotNewServiceImpl implements BotNewService {
     }
 
     @Override
+    public List<HashMap<String, Object>> selectHellRewardItemsWithOwnCount() {
+        return botNewDAO.selectHellRewardItemsWithOwnCount();
+    }
+
+    @Override
+    public List<Integer> selectBossItemIds() {
+        return botNewDAO.selectItemIdsByType("BOSS_HELL");
+    }
+
+    @Override
+    public void insertGpRecord(HashMap<String, Object> param) {
+        botNewDAO.insertGpRecord(param);
+    }
+
+    @Override
+    public int selectGpBalance(String userName) {
+        return botNewDAO.selectGpBalance(userName);
+    }
+
+    @Override
     public HashMap<String, Object> lockMacroUser(String userName) {
     	HashMap <String, Object> param = new HashMap<>();
         param.put("userName", userName);


### PR DESCRIPTION
BotNewDAO.java
- selectHellRewardItemsWithOwnCount() 선언 추가
- insertGpRecord(HashMap) 선언 추가
- selectGpBalance(String) 선언 추가

BotNewServiceImpl.java
- 위 3개 + selectBossItemIds() 구현 추가
- selectBossItemIds: DAO 신규 쿼리 없이 selectItemIdsByType("BOSS_HELL") 재사용