### PR TITLE
feat: 아이템 없을 때 1GP 지급 + 7000번대 헬너프 플래그 주석 명확화

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -347,7 +347,8 @@ public class BossAttackController {
 	    int mktHpMaxRate  = (buffs != null && buffs.get("HP_MAX_RATE")   != null) ? buffs.get("HP_MAX_RATE").intValue()   : 0;
 	    int mktAtkMaxRate  = (buffs != null && buffs.get("ATK_MAX_RATE")   != null) ? buffs.get("ATK_MAX_RATE").intValue()   : 0;
 
-	    // 천벌 아이템(7001) 스탯 합산
+	    // 7000번대 보스 아이템(BOSS_HELL 전체) ATK 스탯 합산
+	    // selectHeavenItemBuff: ITEM_TYPE='BOSS_HELL' 전체 합산 (7001~7999 모두 포함)
 	    // BOSS_ITEM_HELL_NERF_EXEMPT=true 이면 ATK만 분리해 헬너프 이후 합산
 	    int heavenAtkMin = 0, heavenAtkMax = 0; // 헬너프 면제 시 후합산 버퍼
 	    if (heavenBuff != null) {

--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -748,19 +748,33 @@ public class BossAttackS3Controller {
                     givePool = new ArrayList<>(getHellRewardItems());
                 }
                 if (givePool.isEmpty()) givePool = new ArrayList<>(getHellRewardItems());
-                int giveItemId = givePool.get(rand.nextInt(givePool.size()));
-                try {
-                    HashMap<String, Object> inv = new HashMap<>();
-                    inv.put("userName", winner);
-                    inv.put("roomName", roomName);
-                    inv.put("itemId",   giveItemId);
-                    inv.put("qty",      1);
-                    inv.put("gainType", "BOSS_HELL");
-                    botNewService.insertInventoryLogTx(inv);
-                    msg.append(NL).append(isFirstDiscovery ? "✨최초 발견! " : "✨ 보상: ")
-                       .append("[").append(winner).append("] item#").append(giveItemId)
-                       .append(isFirstDiscovery ? " (서버 최초 획득!)" : "").append(NL);
-                } catch (Exception e) { /* 지급 실패 무시 */ }
+
+                if (givePool.isEmpty()) {
+                    // 지급할 아이템 없음 → 1 GP 지급 (아이템과 중복 불가)
+                    try {
+                        HashMap<String, Object> gpFallback = new HashMap<>();
+                        gpFallback.put("userName", winner);
+                        gpFallback.put("roomName", roomName);
+                        gpFallback.put("score",    1.0);
+                        gpFallback.put("cmd",      "BOSS_HELL_NO_ITEM_GP");
+                        botNewService.insertGpRecord(gpFallback);
+                        msg.append(NL).append("✨ [").append(winner).append("] 지급 아이템 없음 → 1 GP 지급!").append(NL);
+                    } catch (Exception e) { /* 지급 실패 무시 */ }
+                } else {
+                    int giveItemId = givePool.get(rand.nextInt(givePool.size()));
+                    try {
+                        HashMap<String, Object> inv = new HashMap<>();
+                        inv.put("userName", winner);
+                        inv.put("roomName", roomName);
+                        inv.put("itemId",   giveItemId);
+                        inv.put("qty",      1);
+                        inv.put("gainType", "BOSS_HELL");
+                        botNewService.insertInventoryLogTx(inv);
+                        msg.append(NL).append(isFirstDiscovery ? "✨최초 발견! " : "✨ 보상: ")
+                           .append("[").append(winner).append("] item#").append(giveItemId)
+                           .append(isFirstDiscovery ? " (서버 최초 획득!)" : "").append(NL);
+                    } catch (Exception e) { /* 지급 실패 무시 */ }
+                }
             }
 
         } else {


### PR DESCRIPTION
- 30% 아이템 보상 시 givePool 비어있으면 1 GP 지급 (아이템과 중복 불가) cmd: BOSS_HELL_NO_ITEM_GP
- selectHeavenItemBuff는 BOSS_HELL 전체(7000~7999) 합산 쿼리임을 주석으로 명확화 → BOSS_ITEM_HELL_NERF_EXEMPT 플래그가 7000번대 전체에 적용됨