### PR TITLE
feat: 헬보스 쿨타임 동적화 / 주사위% 표시 / GP수령자 표시 / 반격후 잔여HP 표시

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -469,7 +469,7 @@ public class BossAttackS3Controller {
         String killMsg = "";
         if (isKill) {
             killMsg = calcHellBossReward(roomName, bossStartDate, maxHp);
-            respawnHellBoss();
+            respawnHellBoss(bossStartDate);
         }
 
         // 결과 메시지
@@ -498,6 +498,8 @@ public class BossAttackS3Controller {
 
         if (flag_boss_attack && bossAtkApplied > 0) {
             msg.append("▶ 보스의 반격! 최대HP의 피해! (").append(bossAtkApplied).append(")").append(NL);
+            int remainHp = Math.max(0, ctx.hpMax - bossAtkApplied);
+            msg.append("  └ 남은체력: ").append(remainHp).append("/").append(ctx.hpMax).append(NL);
         }
 
         msg.append(NL);
@@ -523,9 +525,25 @@ public class BossAttackS3Controller {
     private static final DateTimeFormatter SPAWN_DATE_FMT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    private void respawnHellBoss() {
+    /**
+     * 보스 재생성 — 참여 인원수에 따라 쿨타임을 동적 산정
+     *   6명 이하 → 18시간(1080분), 30명 이상 → 6시간(360분)
+     *   수식: cooldownMin = max(360, min(1080, 1080 - (n-6) * 30))
+     */
+    private void respawnHellBoss(String bossStartDate) {
         try {
             Random rand = new Random();
+
+            // 참여 인원수 조회 (쿨타임 산정)
+            int participantCount = 6; // 기본값 (조회 실패 시)
+            try {
+                HashMap<String, Object> q = new HashMap<>();
+                q.put("bossStartDate", bossStartDate);
+                List<HashMap<String, Object>> participants = botS3Service.selectHellTop3Contributors(q);
+                if (participants != null && !participants.isEmpty()) participantCount = participants.size();
+            } catch (Exception ignored) {}
+            long cooldownMin = Math.max(360, Math.min(1080, 1080 - (long)(participantCount - 6) * 30));
+
             // 최근 공격 평균 데미지 기반으로 120~150회 분량 HP 산정
             long rawHp;
             try {
@@ -548,8 +566,8 @@ public class BossAttackS3Controller {
             bossMap.put("defPower",    randInt(rand, BOSS_DEF_POWER_MIN,  BOSS_DEF_POWER_MAX));
             bossMap.put("evadeRate",   randInt(rand, BOSS_EVADE_RATE_MIN, BOSS_EVADE_RATE_MAX));
             bossMap.put("critDefRate", randInt(rand, BOSS_CRIT_DEF_MIN,   BOSS_CRIT_DEF_MAX));
-            // 24시간 후 등장
-            bossMap.put("startDate",   LocalDateTime.now().plusHours(18).format(SPAWN_DATE_FMT));
+            // 참여 인원수 기반 쿨타임 후 등장
+            bossMap.put("startDate",   LocalDateTime.now().plusMinutes(cooldownMin).format(SPAWN_DATE_FMT));
             bossMap.put("hideRule",    HIDE_RULES[rand.nextInt(HIDE_RULES.length)]);
             SP hpSp = SP.fromSp(rawHp);
             bossMap.put("maxHp",    (long) hpSp.getValue());
@@ -686,7 +704,13 @@ public class BossAttackS3Controller {
 
         StringBuilder msg = new StringBuilder();
 
-        if (rand.nextDouble() < 0.30) {
+        // 보상 주사위 (30% 아이템 / 70% GP)
+        double diceRoll = rand.nextDouble();
+        boolean isItemReward = diceRoll < 0.30;
+        msg.append("⚅ 보상 주사위: ").append(String.format("%.1f%%", diceRoll * 100))
+           .append(" → ").append(isItemReward ? "아이템 보상" : "GP 보상").append(NL);
+
+        if (isItemReward) {
             // ────────────────────────────────────────────────────
             // 30% : 2%이상 + 7000번대 미소지자 중 등확률 랜덤 아이템 지급
             // ────────────────────────────────────────────────────
@@ -784,8 +808,6 @@ public class BossAttackS3Controller {
             //   - 미당첨자 전원: 0.2 GP
             //   - MVP(데미지 1위): +0.2 GP 추가 보너스
             // ────────────────────────────────────────────────────
-            msg.append("이번 상급악마 처치에는 아이템 보상이 없습니다.").append(NL);
-
             if (qualified.isEmpty()) {
                 msg.append("GP 지급 대상 없음 (2% 이상 기여자 없음)").append(NL);
             } else {

--- a/src/main/java/my/prac/core/prjbot/dao/BotS3DAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotS3DAO.java
@@ -29,8 +29,11 @@ public interface BotS3DAO {
 	/** [헬보스] 마지막 처치된 보스 조회 (리워드 표시용) */
 	HashMap<String, Object> selectLastKilledHellBoss();
 
-	/** [헬보스] 마지막 보상 수령자 조회 */
+	/** [헬보스] 마지막 보상 수령자 조회 (TBOT_POINT_NEW_INVENTORY) */
 	HashMap<String, Object> selectLastHellRewardRecipient();
+
+	/** [헬보스] 마지막 GP 보상 수령자 조회 (TBOT_POINT_RANK, KILL_GP/NO_ITEM_GP) */
+	HashMap<String, Object> selectLastHellGpRecipient();
 
 	/** [헬보스] 최근 200회 공격의 평균 데미지 */
 	Long selectRecentHellAvgDmg() throws Exception;

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotS3ServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotS3ServiceImpl.java
@@ -64,15 +64,25 @@ public class BotS3ServiceImpl implements BotS3Service {
 			q.put("bossStartDate", startDate);
 
 			List<HashMap<String, Object>> contributors = botS3DAO.selectHellTop3Contributors(q);
-			HashMap<String, Object> rewardRow = botS3DAO.selectLastHellRewardRecipient();
+
+			// 아이템 보상과 GP 보상 중 더 최근 것을 표시
+			HashMap<String, Object> itemRow = botS3DAO.selectLastHellRewardRecipient();
+			HashMap<String, Object> gpRow   = botS3DAO.selectLastHellGpRecipient();
 
 			StringBuilder sb = new StringBuilder();
 			sb.append("[ 최근 처치된 헬보스 결과 ]").append(NL);
-			if (rewardRow != null) {
-				sb.append("★ 보상: [").append(rewardRow.get("USER_NAME"))
-				  .append("] item#").append(rewardRow.get("ITEM_ID"))
-				  .append(" (").append(rewardRow.get("REWARD_DATE")).append(")").append(NL);
+
+			if (itemRow != null) {
+				sb.append("★ 보상(아이템): [").append(itemRow.get("USER_NAME"))
+				  .append("] item#").append(itemRow.get("ITEM_ID"))
+				  .append(" (").append(itemRow.get("REWARD_DATE")).append(")").append(NL);
 			}
+			if (gpRow != null) {
+				sb.append("★ 보상(GP): [").append(gpRow.get("USER_NAME"))
+				  .append("] +").append(String.format("%.2f", Double.parseDouble(gpRow.get("SCORE").toString()))).append(" GP")
+				  .append(" (").append(gpRow.get("REWARD_DATE")).append(")").append(NL);
+			}
+
 			if (contributors != null && !contributors.isEmpty()) {
 				sb.append(NL).append("-- 기여도 TOP --").append(NL);
 				for (HashMap<String, Object> row : contributors) {

--- a/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
@@ -253,6 +253,26 @@
 		 WHERE ROWNUM = 1
 	</select>
 
+	<!-- =====================================================
+	     [S3 헬보스] 마지막 GP 보상 수령자 조회 (TBOT_POINT_RANK)
+	     BOSS_HELL_KILL_GP: 랜덤당첨 / BOSS_HELL_NO_ITEM_GP: 아이템없음 대체GP
+	     ===================================================== -->
+	<select id="selectLastHellGpRecipient" resultType="HashMap">
+		SELECT USER_NAME
+		     , SCORE
+		     , REWARD_DATE
+		  FROM (
+		    SELECT USER_NAME
+		         , SCORE
+		         , to_char(INSERT_DATE, 'mm/dd hh24:mi') AS REWARD_DATE
+		      FROM TBOT_POINT_RANK
+		     WHERE CMD    IN ('BOSS_HELL_KILL_GP', 'BOSS_HELL_NO_ITEM_GP')
+		       AND NEW_YN  = '2'
+		     ORDER BY INSERT_DATE DESC
+		  )
+		 WHERE ROWNUM = 1
+	</select>
+
 	<!-- [S3 헬보스] 최근 200회 공격의 평균 데미지 -->
 	<select id="selectRecentHellAvgDmg" resultType="java.lang.Long">
 	    SELECT NVL(ROUND(AVG(ATK_DMG)), 0)


### PR DESCRIPTION
- [쿨타임] 참여 인원수 기반 동적 쿨타임: 6명=18h → 30명=6h (30분/인 감소, max360~min1080)
- [주사위] 보스 처치 시 보상 주사위 퍼센트 표시 (⚅ 보상 주사위: XX.X% → 아이템/GP 보상)
- [GP표시] getLastKillRewardMsg() 에 GP 수령자 표시 추가 (TBOT_POINT_RANK 조회)
- [반격HP] 보스 반격 피격 시 남은체력 표시 (남은체력: N/MAX)