### PR TITLE
fix: 세트 효과 구매 알림 미작동 수정 + attackInfo 세트 표시 추가

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1715,6 +1715,22 @@ public class BossAttackController {
         }
 
 
+	    // ─ 세트 효과 ─
+	    boolean hasSetEffect = ctx.setCooldownReduce > 0 || ctx.setAtkFinalRate > 0 || ctx.setCritFinalRate > 0
+	            || (ctx.activeSetSpecials != null && !ctx.activeSetSpecials.isEmpty());
+	    if (hasSetEffect) {
+	        sb.append(NL).append("💠 세트 효과:").append(NL);
+	        if (ctx.setAtkFinalRate > 0)
+	            sb.append("  └ 최종공격력 +").append(ctx.setAtkFinalRate).append("%").append(NL);
+	        if (ctx.setCritFinalRate > 0)
+	            sb.append("  └ 최종크리율 +").append(ctx.setCritFinalRate).append("%").append(NL);
+	        if (ctx.setCooldownReduce > 0)
+	            sb.append("  └ 쿨타임 -").append(ctx.setCooldownReduce).append("초").append(NL);
+	        if (ctx.activeSetSpecials != null) {
+	            for (String sp : ctx.activeSetSpecials) sb.append("  └ ").append(sp).append(NL);
+	        }
+	    }
+
 	    // ─ 인벤토리 ─
 	    try {
 	        sb.append(NL).append("▶ 인벤토리<옵션:/인벤>").append(NL);

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -655,7 +655,8 @@
 	        NVL(i.CRI_DMG,   0) AS CRI_DMG,
 	        NVL(i.HP_MAX_RATE,   0) AS HP_MAX_RATE,
 	        NVL(i.ATK_MAX_RATE,   0) AS ATK_MAX_RATE,
-	        i.TARGET_LV
+	        i.TARGET_LV,
+	        NVL(i.SET_ID, '') AS SET_ID
 	    FROM TBOT_POINT_NEW_ITEM i
 	    --WHERE i.ITEM_TYPE in ('MARKET','MARKET2')
 	    ORDER BY i.ITEM_ID


### PR DESCRIPTION
- selectMarketItems에 SET_ID 추가 → initCache()로 채워지는 ITEM_DETAIL_CACHE에 SET_ID가 없어 구매 알림이 작동 안 하던 문제 수정
- attackInfo()에 세트 효과 섹션 추가 (최종공격력%, 크리율%, 쿨타임 감소) ctx.set* 필드 활용, 인벤토리 목록 직전에 표시