### PR TITLE
feat: 회피 세트 효과 + 보스 유물 7010/7011 구현

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -368,7 +368,7 @@ public class BossAttackController {
 	    // ── 세트 효과 적용 (flat 보너스) ─────────────────────────────────────────
 	    @SuppressWarnings("unchecked")
 	    List<HashMap<String,Object>> setBonus = (List<HashMap<String,Object>>) invBuffData.get("setBonus");
-	    int setAtkFinalRate = 0, setCritFinalRate = 0, setCooldownReduce = 0;
+	    int setAtkFinalRate = 0, setCritFinalRate = 0, setCooldownReduce = 0, setEvasionRate = 0;
 	    if (setBonus != null) {
 	        for (HashMap<String,Object> b : setBonus) {
 	            String bt = Objects.toString(b.get("BONUS_TYPE"), "");
@@ -383,6 +383,7 @@ public class BossAttackController {
 	                case "ATK_FINAL_RATE":  setAtkFinalRate  += bv; break;
 	                case "CRIT_FINAL_RATE": setCritFinalRate += bv; break;
 	                case "COOLDOWN_REDUCE": setCooldownReduce += bv; break;
+	                case "EVASION_RATE":    setEvasionRate   += bv; break;
 	                default:
 	                    if (bt.startsWith("SPECIAL_")) {
 	                        if (ctx.activeSetSpecials == null) ctx.activeSetSpecials = new ArrayList<>();
@@ -666,6 +667,7 @@ public class BossAttackController {
 	    ctx.setAtkFinalRate   = setAtkFinalRate;
 	    ctx.setCritFinalRate  = setCritFinalRate;
 	    ctx.setCooldownReduce = setCooldownReduce;
+	    ctx.setEvasionRate    = setEvasionRate;
 	    ctx.atkMin = atkMin;
 	    ctx.atkMax = atkMax;
 	    ctx.hpMax  = hpMax;
@@ -1717,7 +1719,7 @@ public class BossAttackController {
 
 	    // ─ 세트 효과 ─
 	    boolean hasSetEffect = ctx.setCooldownReduce > 0 || ctx.setAtkFinalRate > 0 || ctx.setCritFinalRate > 0
-	            || (ctx.activeSetSpecials != null && !ctx.activeSetSpecials.isEmpty());
+	            || ctx.setEvasionRate > 0 || (ctx.activeSetSpecials != null && !ctx.activeSetSpecials.isEmpty());
 	    if (hasSetEffect) {
 	        sb.append(NL).append("※ 세트 효과:").append(NL);
 	        if (ctx.setAtkFinalRate > 0)
@@ -1726,6 +1728,8 @@ public class BossAttackController {
 	            sb.append("  └ 최종크리율 +").append(ctx.setCritFinalRate).append("%").append(NL);
 	        if (ctx.setCooldownReduce > 0)
 	            sb.append("  └ 쿨타임 -").append(ctx.setCooldownReduce).append("초").append(NL);
+	        if (ctx.setEvasionRate > 0)
+	            sb.append("  └ 회피율 ").append(ctx.setEvasionRate).append("%").append(NL);
 	        if (ctx.activeSetSpecials != null) {
 	            for (String sp : ctx.activeSetSpecials) sb.append("  └ ").append(sp).append(NL);
 	        }
@@ -3535,6 +3539,18 @@ public class BossAttackController {
 		s.calc     = s.dmg.calc;
 		s.flags    = s.dmg.flags;
 		s.willKill = s.dmg.willKill;
+
+		// ── 세트 회피: monPattern 1,4,5,6 회피 판정 ──────────────────────────────
+		if (s.ctx.setEvasionRate > 0) {
+		    int mp = s.flags.monPattern;
+		    if ((mp == 1 || mp == 4 || mp == 5 || mp == 6)
+		            && ThreadLocalRandom.current().nextInt(100) < s.ctx.setEvasionRate) {
+		        String origMsg = s.calc.patternMsg != null ? s.calc.patternMsg : "";
+		        s.calc.monDmg   = 0;
+		        s.calc.endBattle = false;
+		        s.calc.patternMsg = origMsg + " → [회피!]";
+		    }
+		}
 
 		// 11-후) 축복술사
 		if ("축복술사".equals(s.job) && s.dmg.calc.atkDmg > 0) {

--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -245,6 +245,13 @@ public class BossAttackS3Controller {
         // 보스 회피 판정
         boolean isEvade = !heavensPunishment && (Math.random() < bossEvadeRate / 100.0);
 
+        // [7010] 회피무시 유물: 보스가 회피해도 공격 관통
+        String bossEvadeIgnoreMsg = "";
+        if (isEvade && ownedBoss.contains(7010)) {
+            isEvade = false;
+            bossEvadeIgnoreMsg = "[회피무시] 보스가 회피했지만 공격했다!" + NL;
+        }
+
         // 데미지 계산
         long damage = 0;
         boolean isCritical = false;
@@ -252,6 +259,7 @@ public class BossAttackS3Controller {
         String dmgMsg = "";
         String bossDefMsg = "";
         String hideMsg = "";
+        String hideIgnoreMsg = "";
         String windSlashMsg = "";
 
         if (!isEvade) {
@@ -259,8 +267,14 @@ public class BossAttackS3Controller {
             // 보스 기본 크리율 10% 고정 (S2 크리율 미적용), 초강력치명타는 크리 발동 시 10% 확률
             int totalCritPercent = Math.max(0, 100 - critDefRate);
 
-            // HIDE_RULE: 특정 시간대 치명타 불가 (천벌/디버프 중엔 무시)
-            hideMsg = applyHideRule(hideRule, heavensPunishment || flag_boss_debuff);
+            // HIDE_RULE: 특정 시간대 치명타 불가 (천벌/디버프/7011 중엔 무시)
+            // [7011] 꿰뚫는 눈: 보스가 숨어있어도 온전한 데미지
+            boolean has7011 = ownedBoss.contains(7011);
+            String rawHideMsg = applyHideRule(hideRule, false); // 7011 없이 체크
+            if (has7011 && !rawHideMsg.isEmpty()) {
+                hideIgnoreMsg = "[꿰뚫는 눈] 보스가 숨어있지만 온전한 데미지!" + NL;
+            }
+            hideMsg = applyHideRule(hideRule, heavensPunishment || flag_boss_debuff || has7011);
 
             double critMultiplier = Math.max(1.0, ctx.critDmg / 100.0);
 
@@ -415,6 +429,15 @@ public class BossAttackS3Controller {
             bossAtkApplied = Math.max(1, (int)(ctx.hpMax * atkPct / 100.0));
         }
 
+        // 세트 회피: 보스 반격 회피 판정
+        String bossAtkEvadeMsg = "";
+        if (flag_boss_attack && bossAtkApplied > 0 && ctx.setEvasionRate > 0
+                && ThreadLocalRandom.current().nextInt(100) < ctx.setEvasionRate) {
+            bossAtkApplied = 0;
+            flag_boss_attack = false;
+            bossAtkEvadeMsg = "[회피!] 보스의 반격을 피했습니다!" + NL;
+        }
+
         // [7005] 가시갑옷: 받은 피해의 10% 반사 → totalDamage에 추가 후 HP 재계산
         int reflectDmg = 0;
         String reflectMsg = "";
@@ -491,12 +514,14 @@ public class BossAttackS3Controller {
         if (!isEvade) {
             msg.append("▶ 입힌 데미지: ").append(damage).append(NL);
             msg.append(dmgMsg).append(NL);
+            if (!bossEvadeIgnoreMsg.isEmpty()) msg.append(bossEvadeIgnoreMsg);
             if (!windSlashMsg.isEmpty()) msg.append(windSlashMsg);
             if (thiefHit2) {
                 msg.append("⚔ 2타 데미지: ").append(damage2).append(NL);
                 msg.append(dmgMsg2).append(NL);
                 if (!bossDefMsg2.isEmpty()) msg.append(bossDefMsg2);
             }
+            if (!hideIgnoreMsg.isEmpty()) msg.append(hideIgnoreMsg);
             if (!hideMsg.isEmpty())     msg.append(hideMsg);
             if (!reflectMsg.isEmpty())  msg.append(reflectMsg);
             if (!spRewardMsg.isEmpty()) msg.append(spRewardMsg);
@@ -508,6 +533,7 @@ public class BossAttackS3Controller {
             msg.append("보스가 공격을 회피했습니다! 데미지 0!").append(NL);
         }
 
+        if (!bossAtkEvadeMsg.isEmpty()) msg.append(bossAtkEvadeMsg);
         if (flag_boss_attack && bossAtkApplied > 0) {
             msg.append("▶ 보스의 반격! 최대HP의 피해! (").append(bossAtkApplied).append(")").append(NL);
             int remainHp = Math.max(0, ctx.hpMax - bossAtkApplied);

--- a/src/main/java/my/prac/core/game/dto/UserBattleContext.java
+++ b/src/main/java/my/prac/core/game/dto/UserBattleContext.java
@@ -96,4 +96,5 @@ public class UserBattleContext {
 	public int setAtkFinalRate   = 0; // 최종 공격력 증가율 (%)
 	public int setCritFinalRate  = 0; // 최종 크리율 증가율 (%)
 	public int setCooldownReduce = 0; // 쿨타임 감소 (초)
+	public int setEvasionRate    = 0; // 몬스터/보스 공격 회피율 (%)
 }


### PR DESCRIPTION
[세트 효과 - 회피]
- BONUS_TYPE 'EVASION_RATE' 추가 (ctx.setEvasionRate)
- 일반몬스터 monPattern 1,4,5,6 발동 시 회피율% 로 피해/전투종료 무효화
- S3 헬보스 반격(bossAtkApplied) 발동 시 회피율% 로 회피 가능

[유물 7010 - 회피무시의 눈동자]
- 보스가 회피 판정되어도 공격 관통
- 메시지: "[회피무시] 보스가 회피했지만 공격했다!"

[유물 7011 - 꿰뚫는 눈의 유물]
- 보스 숨기(아침/점심/저녁/새벽) 시간대에도 치명타 허용, 온전한 데미지
- 메시지: "[꿰뚫는 눈] 보스가 숨어있지만 온전한 데미지!"

[attackInfo 표시]
- setEvasionRate > 0 시 "└ 회피율 N%" 표시

[DB] 7010, 7011 TBOT_POINT_NEW_ITEM INSERT 완료