### PR TITLE
fix: 아이템 시뮬 헌터랭크/레벨스탯/세트효과 수정 + 구매판매 PK충돌 방지

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -99,6 +99,11 @@ public class BossAttackController {
 	private static volatile long TOP1_SP_CACHE = 0L;
 	private static volatile long TOP1_SP_CACHE_TS = 0L;
 	private static final long TOP1_SP_CACHE_TTL_MS = 3_600_000L;
+
+	// 다중 구매 시 insertPointRank 합산용 ThreadLocal (합산 모드일 때만 non-null)
+	private static final ThreadLocal<SP[]> MULTI_BUY_COST_TL = new ThreadLocal<>();
+	// 다중 판매 시 insertPointRank 합산용 ThreadLocal (합산 모드일 때만 non-null)
+	private static final ThreadLocal<SP[]> MULTI_SELL_TOTAL_TL = new ThreadLocal<>();
 	
 	/* ===== DI ===== */
 	@Lazy @Autowired BossAttackS3Controller bossAttackS3Controller;
@@ -2281,12 +2286,17 @@ public class BossAttackController {
 	    }
 
 	    // 멀티 구매: 콤마 포함 시
-	    if (rawParam.contains(",")) {
-	        return buyMultiItems(roomName, userName, rawParam);
+	    if (!botNewService.tryAcquireUserActionLock(userName)) {
+	        return "⏳ 처리 중입니다. 잠시 후 다시 시도해 주세요.";
 	    }
-
-	    // 단일 구매
-	    return buySingleItem(roomName, userName, rawParam);
+	    try {
+	        if (rawParam.contains(",")) {
+	            return buyMultiItems(roomName, userName, rawParam);
+	        }
+	        return buySingleItem(roomName, userName, rawParam);
+	    } finally {
+	        botNewService.releaseUserActionLock(userName);
+	    }
 	}
 
 	
@@ -2318,21 +2328,40 @@ public class BossAttackController {
 
 	    StringBuilder sb = new StringBuilder("▶ 일괄 구매 결과").append(NL);
 
-	    // 2) 아이템별 처리: qty=1이면 기존 단일 구매, qty>1이면 배치 구매
-	    for (java.util.Map.Entry<String, Integer> entry : itemQtyMap.entrySet()) {
-	        String itemToken = entry.getKey();
-	        int qty = entry.getValue();
-	        String label = resolveItemLabel(itemToken);
+	    // ThreadLocal 설정: 각 buySingleItem/buyBatch 가 insertPointRank 를 직접 호출하지 않고
+	    // 여기서 한 번만 합산하여 PK 충돌 방지
+	    MULTI_BUY_COST_TL.set(new SP[]{new SP(0, "")});
+	    try {
+	        // 2) 아이템별 처리: qty=1이면 기존 단일 구매, qty>1이면 배치 구매
+	        for (java.util.Map.Entry<String, Integer> entry : itemQtyMap.entrySet()) {
+	            String itemToken = entry.getKey();
+	            int qty = entry.getValue();
+	            String label = resolveItemLabel(itemToken);
 
-	        sb.append(NL).append("[").append(label);
-	        if (qty > 1) sb.append(" ×").append(qty);
-	        sb.append("]").append(NL);
+	            sb.append(NL).append("[").append(label);
+	            if (qty > 1) sb.append(" ×").append(qty);
+	            sb.append("]").append(NL);
 
-	        if (qty == 1) {
-	            sb.append(buySingleItem(roomName, userName, itemToken)).append(NL);
-	        } else {
-	            sb.append(buyBatch(roomName, userName, itemToken, qty)).append(NL);
+	            if (qty == 1) {
+	                sb.append(buySingleItem(roomName, userName, itemToken)).append(NL);
+	            } else {
+	                sb.append(buyBatch(roomName, userName, itemToken, qty)).append(NL);
+	            }
 	        }
+
+	        // 합산 비용 한 번에 차감
+	        SP totalCost = MULTI_BUY_COST_TL.get()[0];
+	        if (totalCost.getValue() > 0 || totalCost.getUnit().length() > 0) {
+	            HashMap<String, Object> pr = new HashMap<>();
+	            pr.put("userName", userName);
+	            pr.put("roomName", roomName);
+	            pr.put("score",    -totalCost.getValue());
+	            pr.put("scoreExt", totalCost.getUnit());
+	            pr.put("cmd",      "BUY");
+	            botNewService.insertPointRank(pr);
+	        }
+	    } finally {
+	        MULTI_BUY_COST_TL.remove();
 	    }
 
 	    return sb.toString();
@@ -2454,14 +2483,19 @@ public class BossAttackController {
 	    // ── 최종 HP 반영 1회 ────────────────────────────────────────────
 	    botNewService.updateUserHpOnlyTx(userName, "", (int) currentHp);
 
-	    // ── SP 차감 1회 ─────────────────────────────────────────────────
-	    HashMap<String, Object> pr = new HashMap<>();
-	    pr.put("userName", userName);
-	    pr.put("roomName", roomName);
-	    pr.put("score",    -totalCost.getValue());
-	    pr.put("scoreExt", totalCost.getUnit());
-	    pr.put("cmd",      "BUY");
-	    botNewService.insertPointRank(pr);
+	    // ── SP 차감 1회 (다중구매 모드이면 ThreadLocal 에 누적, 단건이면 즉시 처리) ────
+	    SP[] buyTl = MULTI_BUY_COST_TL.get();
+	    if (buyTl != null) {
+	        buyTl[0] = buyTl[0].add(totalCost);
+	    } else {
+	        HashMap<String, Object> pr = new HashMap<>();
+	        pr.put("userName", userName);
+	        pr.put("roomName", roomName);
+	        pr.put("score",    -totalCost.getValue());
+	        pr.put("scoreExt", totalCost.getUnit());
+	        pr.put("cmd",      "BUY");
+	        botNewService.insertPointRank(pr);
+	    }
 
 	    // ── 물약 사용 업적 체크 1회 ─────────────────────────────────────
 	    String achvMsg = "";
@@ -2694,14 +2728,19 @@ public class BossAttackController {
 	    }
 	   
 
-	    // 결제 (포인트 차감)
-	    HashMap<String, Object> pr = new HashMap<>();
-	    pr.put("userName", userName);
-	    pr.put("roomName", roomName);
-	    pr.put("score", -itemPrice.getValue());
-	    pr.put("scoreExt", itemPrice.getUnit());
-	    pr.put("cmd", "BUY");
-	    botNewService.insertPointRank(pr);
+	    // 결제 (포인트 차감 — 다중구매 모드이면 ThreadLocal 에 누적, 단건이면 즉시 처리)
+	    SP[] singleBuyTl = MULTI_BUY_COST_TL.get();
+	    if (singleBuyTl != null) {
+	        singleBuyTl[0] = singleBuyTl[0].add(itemPrice);
+	    } else {
+	        HashMap<String, Object> pr = new HashMap<>();
+	        pr.put("userName", userName);
+	        pr.put("roomName", roomName);
+	        pr.put("score", -itemPrice.getValue());
+	        pr.put("scoreExt", itemPrice.getUnit());
+	        pr.put("cmd", "BUY");
+	        botNewService.insertPointRank(pr);
+	    }
 
 	    // 구매 후 포인트
 	    SP afterUserPoint=null;
@@ -4426,39 +4465,137 @@ public class BossAttackController {
 	        return "판매할 아이템명을 입력해주세요." + NL + "예) /판매 도토리 5";
 	    }
 
-	    String slotResult = checkSlotSell(userName, roomName, itemNameRaw);
-	    if (slotResult != null) return slotResult;
+	    if (!botNewService.tryAcquireUserActionLock(userName)) {
+	        return "⏳ 처리 중입니다. 잠시 후 다시 시도해 주세요.";
+	    }
+	    try {
+	        // 콤마 기반 다중 판매
+	        if (itemNameRaw.contains(",")) {
+	            return sellMultiItems(userName, roomName, itemNameRaw);
+	        }
 
-	    Integer itemId = resolveItemId(itemNameRaw);
+	        String slotResult = checkSlotSell(userName, roomName, itemNameRaw);
+	        if (slotResult != null) return slotResult;
 
-	    // 300/500/600/900번대 판매 불가
-	    if (itemId != null &&
-	        ((itemId >= 300 && itemId < 400) || (itemId >= 500 && itemId < 700) || (itemId >= 900 && itemId < 1000))) {
-	        return "[" + itemNameRaw + "]은(는) 판매할 수 없는 아이템입니다.";
+	        Integer itemId = resolveItemId(itemNameRaw);
+
+	        // 300/500/600/900번대 판매 불가
+	        if (itemId != null &&
+	            ((itemId >= 300 && itemId < 400) || (itemId >= 500 && itemId < 700) || (itemId >= 900 && itemId < 1000))) {
+	            return "[" + itemNameRaw + "]은(는) 판매할 수 없는 아이템입니다.";
+	        }
+
+	        if (itemId == null) {
+	            return "해당 아이템을 찾을 수 없습니다: " + itemNameRaw;
+	        }
+
+	        List<HashMap<String,Object>> rows =
+	                botNewService.selectInventoryRowsForSale(userName, roomName, itemId);
+	        itemNameRaw = resolveItemLabel(itemNameRaw);
+
+	        if (rows == null || rows.isEmpty()) {
+	            return "인벤토리에 보유 중인 [" + itemNameRaw + "]이(가) 없습니다.";
+	        }
+
+	        SellResult result = executeSell(
+	                userName,
+	                roomName,
+	                rows,
+	                null,
+	                reqQty,
+	                false
+	        );
+
+	        return buildSellMessage(userName, itemNameRaw, reqQty, result);
+	    } finally {
+	        botNewService.releaseUserActionLock(userName);
+	    }
+	}
+
+	// 콤마 기반 다중 판매: PK 충돌 방지를 위해 insertPointRank 를 단 1회만 호출
+	private String sellMultiItems(String userName, String roomName, String raw) throws Exception {
+	    String[] tokens = raw.split(",");
+
+	    StringBuilder sb = new StringBuilder("▶ 일괄 판매 결과").append(NL);
+
+	    MULTI_SELL_TOTAL_TL.set(new SP[]{SP.of(0, "")});
+	    int totalSold = 0;
+	    int totalGp = 0;
+	    try {
+	        for (String t : tokens) {
+	            String token = (t == null ? "" : t.trim());
+	            if (token.isEmpty()) continue;
+
+	            int qty = Integer.MAX_VALUE;
+	            String itemToken = token;
+	            java.util.regex.Matcher m =
+	                java.util.regex.Pattern.compile("(.+?)[xX\\*](\\d+)$").matcher(token);
+	            if (m.matches()) {
+	                itemToken = m.group(1).trim();
+	                qty = Math.max(1, MiniGameUtil.parseIntSafe(m.group(2)));
+	            }
+
+	            String label = resolveItemLabel(itemToken);
+	            sb.append(NL).append("[").append(label).append("]").append(NL);
+
+	            // 카테고리 키워드 체크
+	            String slotKey = MiniGameUtil.SLOT_MAP.get(itemToken);
+	            List<HashMap<String,Object>> rows;
+	            boolean sellAll;
+	            String slotFilter;
+	            if (slotKey != null) {
+	                rows = botNewService.selectAllInventoryRowsForSale(userName, roomName);
+	                sellAll = true;
+	                slotFilter = slotKey;
+	            } else {
+	                Integer itemId;
+	                try { itemId = resolveItemId(itemToken); } catch (Exception e) { itemId = null; }
+	                if (itemId == null) { sb.append("아이템을 찾을 수 없습니다.").append(NL); continue; }
+	                if ((itemId >= 300 && itemId < 400) || (itemId >= 500 && itemId < 700) || (itemId >= 900 && itemId < 1000)) {
+	                    sb.append("판매 불가 아이템입니다.").append(NL); continue;
+	                }
+	                rows = botNewService.selectInventoryRowsForSale(userName, roomName, itemId);
+	                sellAll = (qty == Integer.MAX_VALUE);
+	                slotFilter = null;
+	            }
+
+	            if (rows == null || rows.isEmpty()) { sb.append("보유 재고 없음").append(NL); continue; }
+
+	            SellResult r = executeSell(userName, roomName, rows, slotFilter, qty, sellAll);
+	            totalSold += r.sold;
+	            totalGp += r.gpGranted;
+	            if (r.sold > 0) sb.append("판매: ").append(r.sold).append("개 / ").append(r.total).append(NL);
+	            else sb.append("판매 가능한 재고 없음").append(NL);
+	        }
+
+	        // 합산 금액 한 번에 차감
+	        SP totalSp = MULTI_SELL_TOTAL_TL.get()[0];
+	        if (totalSold > 0 && (totalSp.getValue() > 0 || totalSp.getUnit().length() > 0)) {
+	            HashMap<String, Object> pr = new HashMap<>();
+	            pr.put("userName", userName);
+	            pr.put("roomName", roomName);
+	            pr.put("score",    totalSp.getValue());
+	            pr.put("scoreExt", totalSp.getUnit());
+	            pr.put("cmd",      "SELL_EQUIP");
+	            botNewService.insertPointRank(pr);
+	        }
+	    } finally {
+	        MULTI_SELL_TOTAL_TL.remove();
 	    }
 
-	    if (itemId == null) {
-	        return "해당 아이템을 찾을 수 없습니다: " + itemNameRaw;
-	    }
+	    if (totalSold <= 0) return "판매 가능한 재고가 없습니다.";
 
-	    List<HashMap<String,Object>> rows =
-	            botNewService.selectInventoryRowsForSale(userName, roomName, itemId);
-	    itemNameRaw = resolveItemLabel(itemNameRaw);
+	    SP curPoint = SP.of(0, "");
+	    try {
+	        HashMap<String,Object> p = botNewService.selectCurrentPoint(userName, null);
+	        curPoint = new SP(Double.parseDouble(Objects.toString(p.get("SCORE"), "0")),
+	                Objects.toString(p.get("SCORE_EXT"), ""));
+	    } catch (Exception ignore) {}
 
-	    if (rows == null || rows.isEmpty()) {
-	        return "인벤토리에 보유 중인 [" + itemNameRaw + "]이(가) 없습니다.";
-	    }
-	    
-	    SellResult result = executeSell(
-	            userName,
-	            roomName,
-	            rows,
-	            null,
-	            reqQty,
-	            false
-	    );
-
-	    return buildSellMessage(userName, itemNameRaw, reqQty, result);
+	    sb.append(NL).append("- 총 판매 수량: ").append(totalSold).append("개");
+	    if (totalGp > 0) sb.append(NL).append("- GP 획득: ").append(totalGp).append(" GP");
+	    sb.append(NL).append("- 현재 포인트: ").append(curPoint);
+	    return sb.toString();
 	}
 
 	public String gpGacha(HashMap<String, Object> map) {
@@ -4835,15 +4972,19 @@ public class BossAttackController {
 
 		botNewService.updateInventoryDelBatch(delParam);
 
-		HashMap<String, Object> pr = new HashMap<>();
-		pr.put("userName", userName);
-		pr.put("roomName", roomName);
-		pr.put("score", total.getValue());
-		pr.put("scoreExt", total.getUnit());
-		pr.put("cmd", "SELL_EQUIP");
-
-		if (total.getValue() > 0 || total.getUnit().length() > 0)
-			botNewService.insertPointRank(pr);
+		// 다중판매 모드이면 ThreadLocal에 누적, 단건이면 즉시 처리
+		SP[] sellTl = MULTI_SELL_TOTAL_TL.get();
+		if (sellTl != null) {
+		    sellTl[0] = sellTl[0].add(total);
+		} else if (total.getValue() > 0 || total.getUnit().length() > 0) {
+		    HashMap<String, Object> pr = new HashMap<>();
+		    pr.put("userName", userName);
+		    pr.put("roomName", roomName);
+		    pr.put("score", total.getValue());
+		    pr.put("scoreExt", total.getUnit());
+		    pr.put("cmd", "SELL_EQUIP");
+		    botNewService.insertPointRank(pr);
+		}
 
 		// GP 지급 (7000번대 보스 아이템 판매)
 		if (gpCount > 0) {

--- a/src/main/java/my/prac/api/loa/controller/LoaEquipSimViewController.java
+++ b/src/main/java/my/prac/api/loa/controller/LoaEquipSimViewController.java
@@ -20,6 +20,15 @@ public class LoaEquipSimViewController {
     @Resource(name = "core.prjbot.BotNewService")
     BotNewService botNewService;
 
+    // 세트 보너스 정의 캐시 (서버 기동 후 최초 1회 로딩, 초기화 명령으로 갱신 가능)
+    private volatile List<HashMap<String,Object>> setBonusDefsCache = null;
+
+    private List<HashMap<String,Object>> getSetBonusDefsCached() {
+        if (setBonusDefsCache != null) return setBonusDefsCache;
+        try { setBonusDefsCache = botNewService.selectAllSetBonusDefs(); } catch (Exception ignore) {}
+        return setBonusDefsCache;
+    }
+
     /** JSP 뷰 페이지 */
     @GetMapping("/equip-sim-view")
     public String equipSimPage() {
@@ -27,7 +36,7 @@ public class LoaEquipSimViewController {
     }
 
     /**
-     * 초기 데이터: 유저 기본 스탯 + 전체 아이템(보유/미보유 포함) + jobList(JOB_DEFS 기준)
+     * 초기 데이터: 유저 기본 스탯(레벨 기반 재계산) + 전체 아이템 + jobList
      */
     @GetMapping("/api/equip-sim-init")
     @ResponseBody
@@ -50,22 +59,19 @@ public class LoaEquipSimViewController {
         String hunterGrade  = resolveHunterGrade(userName);
         double hellNerfMult = MiniGameUtil.getHellNerfMult(hunterGrade);
 
-        // 전체 아이템 (보유 + 미보유 모두)
         List<HashMap<String,Object>> allItems = new ArrayList<>();
-        try {
-            allItems = botNewService.selectAllItemsWithOwned(userName);
-        } catch (Exception ignore) {}
+        try { allItems = botNewService.selectAllItemsWithOwned(userName); } catch (Exception ignore) {}
 
-        // JOB_DEFS 기준 활성 직업 목록
         List<String> jobList = new ArrayList<>(MiniGameUtil.JOB_DEFS.keySet());
 
         Map<String,Object> userMap = new LinkedHashMap<>();
         userMap.put("userName",    userName);
-        userMap.put("atkMin",      u.atkMin);
-        userMap.put("atkMax",      u.atkMax);
-        userMap.put("hpMax",       u.hpMax);
-        userMap.put("hpRegen",     u.hpRegen);
-        userMap.put("critRate",    u.critRate);
+        // 레벨 기반으로 재계산한 기본 스탯 반환 (DB 값이 오래된 경우 대비)
+        userMap.put("atkMin",      MiniGameUtil.calcBaseAtkMin(u.lv));
+        userMap.put("atkMax",      MiniGameUtil.calcBaseAtkMax(u.lv));
+        userMap.put("hpMax",       MiniGameUtil.calcBaseHpMax(u.lv));
+        userMap.put("hpRegen",     MiniGameUtil.calcBaseHpRegen(u.lv));
+        userMap.put("critRate",    MiniGameUtil.calcBaseCritRate(u.lv));
         userMap.put("critDmg",     u.critDmg);
         userMap.put("lv",          u.lv);
         userMap.put("job",         u.job == null ? "" : u.job.trim());
@@ -81,7 +87,7 @@ public class LoaEquipSimViewController {
     }
 
     /**
-     * 실시간 스탯 계산
+     * 실시간 스탯 계산 (BossAttackController.calcUserBattleContext 와 동일 흐름)
      * Body: { userName, simJob, hellMode, equippedItems: [{itemId, qty}] }
      */
     @PostMapping("/api/equip-sim-calc")
@@ -108,10 +114,19 @@ public class LoaEquipSimViewController {
 
         String job = simJob.isEmpty() ? (u.job == null ? "" : u.job.trim()) : simJob;
 
-        // ── 아이템 스탯 합산 ─────────────────────────────────────────
+        // ── 1. 레벨 기반 기본 스탯 ──────────────────────────────────────
+        int baseAtkMin  = MiniGameUtil.calcBaseAtkMin(u.lv);
+        int baseAtkMax  = MiniGameUtil.calcBaseAtkMax(u.lv);
+        int baseHpMax   = MiniGameUtil.calcBaseHpMax(u.lv);
+        int baseRegen   = MiniGameUtil.calcBaseHpRegen(u.lv);
+        int baseCrit    = MiniGameUtil.calcBaseCritRate(u.lv);
+        int baseCritDmg = u.critDmg; // 크리 데미지는 레벨 기반 아님
+
+        // ── 2. 장착 아이템 스탯 합산 + 세트ID 카운트 ─────────────────────
         int mktAtkMin=0, mktAtkMax=0, mktCrit=0, mktRegen=0;
         int mktHpMax=0, mktCritDmg=0, mktHpMaxRate=0, mktAtkMaxRate=0;
         Set<Integer> bossEquipped = new HashSet<>();
+        Map<String,Integer> setIdCounts = new LinkedHashMap<>();
 
         for (Map<String,Object> ei : equippedList) {
             int itemId = ei.get("itemId") instanceof Number ? ((Number)ei.get("itemId")).intValue() : 0;
@@ -130,19 +145,89 @@ public class LoaEquipSimViewController {
             mktHpMaxRate += safeInt(item.get("HP_MAX_RATE"))  * qty;
             mktAtkMaxRate+= safeInt(item.get("ATK_MAX_RATE")) * qty;
             if (itemId >= 7000 && itemId < 8000) bossEquipped.add(itemId);
+
+            // 세트 효과 계산용 SET_ID 카운트 (아이템 단위, qty 무관 1개로)
+            String setId = Objects.toString(item.get("SET_ID"), "");
+            if (!setId.isEmpty()) setIdCounts.merge(setId, 1, Integer::sum);
         }
 
-        // ── 헌터 등급 + 보너스 ──────────────────────────────────────
-        String hunterGrade = resolveHunterGrade(userName);
+        // ── 3. 세트 효과 (시뮬 장착 아이템 기준, BossAttackController 동일 방식) ──
+        int setAtkFinalRate = 0, setCritFinalRate = 0, setCooldownReduce = 0, setEvasionRate = 0;
+        if (!setIdCounts.isEmpty()) {
+            List<HashMap<String,Object>> setBonusDefs = getSetBonusDefsCached();
+            if (setBonusDefs != null) {
+                for (HashMap<String,Object> b : setBonusDefs) {
+                    String setId = Objects.toString(b.get("SET_ID"), "");
+                    int reqCnt   = safeInt(b.get("REQUIRED_CNT"));
+                    Integer owned = setIdCounts.get(setId);
+                    if (owned == null || owned < reqCnt) continue;
+                    String bt = Objects.toString(b.get("BONUS_TYPE"), "");
+                    int    bv = safeInt(b.get("BONUS_VALUE"));
+                    switch (bt) {
+                        case "ATK_MIN":         mktAtkMin    += bv; break;
+                        case "ATK_MAX":         mktAtkMax    += bv; break;
+                        case "HP_MAX":          mktHpMax     += bv; break;
+                        case "ATK_CRI":         mktCrit      += bv; break;
+                        case "CRI_DMG":         mktCritDmg   += bv; break;
+                        case "HP_REGEN":        mktRegen     += bv; break;
+                        case "ATK_FINAL_RATE":  setAtkFinalRate  += bv; break;
+                        case "CRIT_FINAL_RATE": setCritFinalRate += bv; break;
+                        case "COOLDOWN_REDUCE": setCooldownReduce += bv; break;
+                        case "EVASION_RATE":    setEvasionRate   += bv; break;
+                        default: break;
+                    }
+                }
+            }
+        }
+
+        // ── 4. 어둠사냥꾼: 아이템 HP/Regen ×1.25 (hunter 보너스 이전 적용) ──
+        if ("어둠사냥꾼".equals(job)) {
+            mktHpMax  = (int) Math.round(mktHpMax  * 1.25);
+            mktRegen  = (int) Math.round(mktRegen  * 1.25);
+        }
+
+        // ── 5. 헌터 등급 + 보너스 (BossAttackController와 동일 로직) ───────
+        String hunterGrade = "F";
         int hunterAtk=0, hunterHp=0, hunterRegen=0, hunterCritDmg=0;
+        try {
+            AttackDeathStat ads = botNewService.selectAttackDeathStats(userName, "");
+            int adjAtk = ads == null ? 0 : ads.totalAttacks + (ads.hunterAttacks * 2);
+            int adjDth = ads == null ? 0 : ads.totalDeaths  + (ads.hunterAttacks / 2);
+            int adjDrp = 0, darkQty = 0, grayQty = 0;
 
-        if ("헌터".equals(job)) {
-            try {
-                AttackDeathStat ads = botNewService.selectAttackDeathStats(userName, "");
-                int totalAttacks = ads == null ? 0 : ads.totalAttacks + (ads.hunterAttacks * 2);
-                int totalDeaths  = ads == null ? 0 : ads.totalDeaths  + (ads.hunterAttacks / 2);
-                int totalDrops   = getDropsFromCache(userName);
+            // 캐시 의존 없이 DB 직접 조회
+            List<HashMap<String,Object>> dropsData = botNewService.selectTotalDropItems(userName);
+            if (dropsData != null) {
+                for (HashMap<String,Object> d : dropsData) {
+                    Object v = d.get("TOTAL_QTY");
+                    String type = Objects.toString(d.get("GAIN_TYPE"), "");
+                    if (v instanceof Number) {
+                        int qty = ((Number)v).intValue();
+                        adjDrp += qty;
+                        if ("DROP5".equals(type)) darkQty += qty;       // 어둠
+                        else if ("DROP9".equals(type)) grayQty += qty;  // 음양
+                    }
+                }
+            }
 
+            // 다크몹/음양 보너스 (S 이하에만 적용, SS이상 제외)
+            int itemBonus = darkQty * 1 + grayQty * 3;
+            String gradeWithout = calcGrade(adjAtk, adjDrp, adjDth);
+            boolean bonusEligible = !"SSS".equals(gradeWithout) && !gradeWithout.startsWith("SS");
+            if (bonusEligible) {
+                int k = adjAtk + itemBonus, dr = adjDrp + itemBonus, de = adjDth + itemBonus;
+                String gWith = calcGrade(k, dr, de);
+                if ("SSS".equals(gWith)) {
+                    gWith = "SS"; // SSS 상한 → SS로 클램프
+                } else {
+                    adjAtk = k; adjDrp = dr; adjDth = de;
+                }
+                hunterGrade = gWith;
+            } else {
+                hunterGrade = gradeWithout;
+            }
+
+            if ("헌터".equals(job)) {
                 int atkCap, hpCap, regenCap, criCap;
                 switch (hunterGrade) {
                     case "SSS": atkCap=8000; hpCap=80000; regenCap=8000; criCap=60; break;
@@ -158,18 +243,12 @@ public class LoaEquipSimViewController {
                     case "D":   atkCap=600;  hpCap=4000;  regenCap=400;  criCap=10; break;
                     default:    atkCap=200;  hpCap=1000;  regenCap=100;  criCap=5;
                 }
-                hunterAtk     = Math.min(totalAttacks/5,  atkCap);
-                hunterHp      = Math.min(totalDrops  /5,  hpCap);
-                hunterRegen   = Math.min(totalDrops  /50, regenCap);
-                hunterCritDmg = Math.min(totalDeaths /5,  criCap);
-            } catch (Exception ignore) {}
-        }
-
-        // 어둠사냥꾼: item HP/Regen 25% 증가
-        if ("어둠사냥꾼".equals(job)) {
-            mktHpMax  = (int) Math.round(mktHpMax  * 1.25);
-            mktRegen  = (int) Math.round(mktRegen  * 1.25);
-        }
+                hunterAtk     = Math.min(adjAtk  / 5,  atkCap);
+                hunterHp      = Math.min(adjDrp  / 5,  hpCap);
+                hunterRegen   = Math.min(adjDrp  / 50, regenCap);
+                hunterCritDmg = Math.min(adjDth  / 5,  criCap);
+            }
+        } catch (Exception ignore) {}
 
         mktAtkMin  += hunterAtk;
         mktAtkMax  += hunterAtk;
@@ -177,33 +256,32 @@ public class LoaEquipSimViewController {
         mktRegen   += hunterRegen;
         mktCritDmg += hunterCritDmg;
 
-        // ── 기본 합산 ────────────────────────────────────────────────
-        int atkMin  = u.atkMin   + mktAtkMin;
-        int atkMax  = u.atkMax   + mktAtkMax;
-        int hpMax   = u.hpMax    + mktHpMax;
-        int regen   = u.hpRegen  + mktRegen;
-        int crit    = u.critRate + mktCrit;
-        int critDmg = u.critDmg  + mktCritDmg;
+        // ── 6. 기본 합산 ──────────────────────────────────────────────────
+        int atkMin  = baseAtkMin + mktAtkMin;
+        int atkMax  = baseAtkMax + mktAtkMax;
+        int hpMax   = baseHpMax  + mktHpMax;
+        int regen   = baseRegen  + mktRegen;
+        int crit    = baseCrit   + mktCrit;
+        int critDmg = baseCritDmg + mktCritDmg;
 
-        // ── 직업 보너스 ──────────────────────────────────────────────
-        if ("검성".equals(job) || "용사".equals(job)) hpMax += u.hpMax * 2;
+        // ── 7. 직업 보너스 (BossAttackController와 동일 순서) ─────────────
+        if ("검성".equals(job) || "용사".equals(job)) hpMax += baseHpMax * 2;
         if ("흡혈귀".equals(job)) regen = 0;
 
-        // 곰: HP = ATK
         if ("곰".equals(job)) {
             int atkSum  = atkMin + atkMax;
-            int critMul = u.critDmg + mktCritDmg;
-            hpMax  = hpMax + (atkSum * critMul / 100);
-            atkMin = hpMax; atkMax = hpMax;
-            crit   = 0; critDmg = 0;
+            int critMul = baseCritDmg + mktCritDmg;
+            hpMax   = hpMax + (atkSum * critMul / 100);
+            atkMin  = hpMax; atkMax = hpMax;
+            crit    = 0; critDmg = 0;
         }
 
-        // ── 비율 보너스 ──────────────────────────────────────────────
+        // ── 8. 비율 보너스 ────────────────────────────────────────────────
         hpMax  += (int) Math.round(hpMax  * mktHpMaxRate  / 100.0);
         atkMin += (int) Math.round(atkMin * mktAtkMaxRate  / 100.0);
         atkMax += (int) Math.round(atkMax * mktAtkMaxRate  / 100.0);
 
-        // ── 헬너프 ───────────────────────────────────────────────────
+        // ── 9. 헬너프 ─────────────────────────────────────────────────────
         if (hellMode) {
             double mult = MiniGameUtil.getHellNerfMult(hunterGrade);
             if (bossEquipped.contains(7007)) mult = Math.max(0.0, mult + 0.03);
@@ -214,13 +292,22 @@ public class LoaEquipSimViewController {
             critDmg = (int) Math.round(critDmg * mult);
         }
 
-        // ── [7009] 진화형 무기 ───────────────────────────────────────
+        // ── 10. [7009] 진화형 무기: 레벨당 공격력 +150 ───────────────────
         if (bossEquipped.contains(7009)) {
             atkMin += u.lv * 150;
             atkMax += u.lv * 150;
         }
 
-        // ── 헌터: 치피전환율 (치명타 100% 초과분 → 치명타 데미지 전환) ──
+        // ── 11. 세트 효과: 최종 비율 보너스 (헬너프 이후, BossAttackController 동일) ──
+        if (setAtkFinalRate > 0) {
+            atkMin += (int) Math.round(atkMin * setAtkFinalRate / 100.0);
+            atkMax += (int) Math.round(atkMax * setAtkFinalRate / 100.0);
+        }
+        if (setCritFinalRate > 0) {
+            crit += (int) Math.round(crit * setCritFinalRate / 100.0);
+        }
+
+        // ── 12. 헌터: 치피전환 (치명타 100% 초과분 → 치명타 데미지 전환) ──
         int criConvert = 0;
         if ("헌터".equals(job) && crit > 100) {
             criConvert = crit - 100;
@@ -228,27 +315,30 @@ public class LoaEquipSimViewController {
             crit       = 100;
         }
 
-        // ── 직업 데미지 배율 (BossAttackController와 동일 값) ────────
+        // ── 13. 직업 데미지 배율 ──────────────────────────────────────────
         double jobDmgMul = getJobDmgMul(job);
         int effAtkMin = (int) Math.round(atkMin * jobDmgMul);
         int effAtkMax = (int) Math.round(atkMax * jobDmgMul);
 
-        // ── 헌터 등급별 criCap (치명타 → 치피전환 상한 안내용) ────────
         int criCap = getCriCapForGrade(hunterGrade);
 
-        result.put("atkMin",      atkMin);
-        result.put("atkMax",      atkMax);
-        result.put("effAtkMin",   effAtkMin);
-        result.put("effAtkMax",   effAtkMax);
-        result.put("jobDmgMul",   jobDmgMul);
-        result.put("hpMax",       hpMax);
-        result.put("regen",       regen);
-        result.put("crit",        crit);
-        result.put("critDmg",     critDmg);
-        result.put("criConvert",  criConvert);
-        result.put("criCap",      criCap);
-        result.put("hunterGrade", hunterGrade);
-        result.put("job",         job);
+        result.put("atkMin",          atkMin);
+        result.put("atkMax",          atkMax);
+        result.put("effAtkMin",       effAtkMin);
+        result.put("effAtkMax",       effAtkMax);
+        result.put("jobDmgMul",       jobDmgMul);
+        result.put("hpMax",           hpMax);
+        result.put("regen",           regen);
+        result.put("crit",            crit);
+        result.put("critDmg",         critDmg);
+        result.put("criConvert",      criConvert);
+        result.put("criCap",          criCap);
+        result.put("hunterGrade",     hunterGrade);
+        result.put("job",             job);
+        result.put("setAtkFinalRate", setAtkFinalRate);
+        result.put("setCritFinalRate",setCritFinalRate);
+        result.put("setCooldown",     setCooldownReduce);
+        result.put("setEvasion",      setEvasionRate);
 
         return ResponseEntity.ok(result);
     }
@@ -276,7 +366,7 @@ public class LoaEquipSimViewController {
         }
     }
 
-    /** 헌터 등급별 전생(죽음) 기반 치명타 데미지 상한 */
+    /** 헌터 등급별 치명타 데미지 상한 */
     private int getCriCapForGrade(String grade) {
         if (grade == null) return 5;
         switch (grade) {
@@ -295,34 +385,49 @@ public class LoaEquipSimViewController {
         }
     }
 
+    /**
+     * 헌터 등급 계산 (BossAttackController / LoaHunterRankViewController와 동일 로직)
+     * - DB 직접 조회 (캐시 불필요)
+     * - 다크몹(DROP5) / 음양(DROP9) 보정 포함
+     */
     private String resolveHunterGrade(String userName) {
         try {
             AttackDeathStat ads = botNewService.selectAttackDeathStats(userName, "");
             int totalAttacks = ads == null ? 0 : ads.totalAttacks + (ads.hunterAttacks * 2);
             int totalDeaths  = ads == null ? 0 : ads.totalDeaths  + (ads.hunterAttacks / 2);
-            int totalDrops   = getDropsFromCache(userName);
-            return calcGrade(totalAttacks, totalDrops, totalDeaths);
+
+            int totalDrops = 0, darkQty = 0, grayQty = 0;
+            List<HashMap<String,Object>> drops = botNewService.selectTotalDropItems(userName);
+            if (drops != null) {
+                for (HashMap<String,Object> d : drops) {
+                    Object v = d.get("TOTAL_QTY");
+                    String type = Objects.toString(d.get("GAIN_TYPE"), "");
+                    if (v instanceof Number) {
+                        int qty = ((Number)v).intValue();
+                        totalDrops += qty;
+                        if ("DROP5".equals(type)) darkQty += qty;
+                        else if ("DROP9".equals(type)) grayQty += qty;
+                    }
+                }
+            }
+
+            int itemBonus = darkQty * 1 + grayQty * 3;
+            String gradeWithout = calcGrade(totalAttacks, totalDrops, totalDeaths);
+            boolean bonusEligible = !"SSS".equals(gradeWithout) && !gradeWithout.startsWith("SS");
+            if (bonusEligible) {
+                int k = totalAttacks + itemBonus, dr = totalDrops + itemBonus, de = totalDeaths + itemBonus;
+                String gWith = calcGrade(k, dr, de);
+                return "SSS".equals(gWith) ? "SS" : gWith;
+            }
+            return gradeWithout;
         } catch (Exception e) { return "F"; }
     }
 
-    private int getDropsFromCache(String userName) {
-        HashMap<String,Object> cached = MiniGameUtil.INV_BUFF_CACHE.get(userName);
-        if (cached == null) return 0;
-        @SuppressWarnings("unchecked")
-        List<HashMap<String,Object>> drops = (List<HashMap<String,Object>>) cached.get("drops");
-        if (drops == null) return 0;
-        int total = 0;
-        for (HashMap<String,Object> d : drops) {
-            Object v = d.get("TOTAL_QTY");
-            if (v instanceof Number) total += ((Number)v).intValue();
-        }
-        return total;
-    }
-
+    /** LoaHunterRankViewController / BossAttackController 와 동일한 등급 계산 */
     private String calcGrade(int atk, int drop, int dth) {
         if (atk >= 50000 && drop >= 100000 && dth >= 1200) return "SSS";
-        if (atk >= 40000 && drop >= 50000  && dth >= 700)  return "SS";
-        if (atk >= 30000 && drop >= 30000  && dth >= 500)  return "S";
+        if (atk >= 40000 && drop >=  50000 && dth >=  700) return "SS";
+        if (atk >= 30000 && drop >=  30000 && dth >=  500) return "S";
         String g;
         g = checkPlus(atk, drop, dth, 20000, 20000, 400, "A"); if (g != null) return g;
         g = checkPlus(atk, drop, dth, 10000, 10000, 200, "B"); if (g != null) return g;
@@ -331,13 +436,13 @@ public class LoaEquipSimViewController {
         return "F";
     }
 
+    /** 3조건 중 3개 충족 → base+, 2개 충족 → base, 1개 이하 → null */
     private String checkPlus(int atk, int drop, int dth,
                               int atkReq, int dropReq, int dthReq, String base) {
-        if (atk < atkReq || drop < dropReq || dth < dthReq) return null;
-        int above = (atk  >= atkReq  * 2 ? 1 : 0)
-                  + (drop >= dropReq * 2 ? 1 : 0)
-                  + (dth  >= dthReq  * 2 ? 1 : 0);
-        return above >= 2 ? base + "+" : base;
+        int m = (atk >= atkReq ? 1 : 0) + (drop >= dropReq ? 1 : 0) + (dth >= dthReq ? 1 : 0);
+        if (m == 3) return base + "+";
+        if (m == 2) return base;
+        return null;
     }
 
     private int safeInt(Object o) {

--- a/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
@@ -192,6 +192,8 @@ public interface BotNewDAO {
 
     List<HashMap<String,Object>> selectActiveSetBonuses(@Param("userName") String userName);
 
+    List<HashMap<String,Object>> selectAllSetBonusDefs();
+
     int selectHellBossAttackCount(String userName);
     int selectHellBossClearCount(String userName);
     List<HashMap<String, Object>> selectJobMasterSeasons(String userName);

--- a/src/main/java/my/prac/core/prjbot/service/BotNewService.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotNewService.java
@@ -152,6 +152,12 @@ public interface BotNewService {
 
     List<HashMap<String,Object>> selectActiveSetBonuses(String userName);
 
+    List<HashMap<String,Object>> selectAllSetBonusDefs();
+
+    /** 유저별 중복 액션(구매/판매) 방지용 락 */
+    boolean tryAcquireUserActionLock(String userName);
+    void releaseUserActionLock(String userName);
+
     // [6-1] 헬보스/직업마스터/룰렛/학살자 업적 관련
     int selectHellBossAttackCount(String userName);
     int selectHellBossClearCount(String userName);

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Resource;
 
@@ -450,6 +451,23 @@ public class BotNewServiceImpl implements BotNewService {
     @Override
     public List<HashMap<String,Object>> selectActiveSetBonuses(String userName) {
         return botNewDAO.selectActiveSetBonuses(userName);
+    }
+
+    @Override
+    public List<HashMap<String,Object>> selectAllSetBonusDefs() {
+        return botNewDAO.selectAllSetBonusDefs();
+    }
+
+    private static final ConcurrentHashMap<String, Boolean> USER_ACTION_LOCKS = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean tryAcquireUserActionLock(String userName) {
+        return USER_ACTION_LOCKS.putIfAbsent(userName, Boolean.TRUE) == null;
+    }
+
+    @Override
+    public void releaseUserActionLock(String userName) {
+        USER_ACTION_LOCKS.remove(userName);
     }
 
     public int selectHellBossAttackCount(String userName) {

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -1828,6 +1828,14 @@
 		ORDER BY i.ITEM_ID
 	</select>
 
+	<!-- 전체 세트 보너스 정의 조회 (시뮬레이션용, 유저 무관) -->
+	<select id="selectAllSetBonusDefs" resultType="hashmap">
+		/* selectAllSetBonusDefs */
+		SELECT SET_ID, REQUIRED_CNT, BONUS_TYPE, BONUS_VALUE, BONUS_DESC
+		FROM TBOT_POINT_NEW_ITEM_SET_BONUS
+		ORDER BY SET_ID, REQUIRED_CNT
+	</select>
+
 	<!-- 유저의 활성 세트 보너스 조회 (보유 아이템 수 >= 발동조건) -->
 	<select id="selectActiveSetBonuses" resultType="hashmap" parameterType="String">
 		/* selectActiveSetBonuses */

--- a/src/main/webapp/WEB-INF/view/nonsession/loa/equip_sim_view.jsp
+++ b/src/main/webapp/WEB-INF/view/nonsession/loa/equip_sim_view.jsp
@@ -193,6 +193,16 @@
       .stat-grid { grid-template-columns:repeat(2,1fr); }
       .item-grid { grid-template-columns:repeat(2,1fr); }
     }
+    .set-effect-bar {
+      display:flex; flex-wrap:wrap; align-items:center; gap:6px;
+      margin-top:10px; padding:6px 10px;
+      background:#f0fdf4; border:1px solid #bbf7d0; border-radius:8px;
+    }
+    .set-effect-title { font-size:12px; font-weight:700; color:#166534; margin-right:4px; }
+    .set-chip {
+      padding:2px 9px; border-radius:10px; font-size:11px; font-weight:600;
+      background:#dcfce7; color:#15803d;
+    }
   </style>
 </head>
 <body>
@@ -271,6 +281,15 @@
           <div class="stat-value conv">{{ stats.criConvert > 0 ? '+' + stats.criConvert + '%' : '-' }}</div>
           <div class="stat-sub">{{ hunterGrade }}등급 전생상한 {{ stats.criCap }}%</div>
         </div>
+      </div>
+
+      <!-- 세트 효과 요약 -->
+      <div v-if="stats.setAtkFinalRate||stats.setCritFinalRate||stats.setCooldown||stats.setEvasion" class="set-effect-bar">
+        <span class="set-effect-title">🔗 세트효과</span>
+        <span v-if="stats.setAtkFinalRate"  class="set-chip">최종공격 +{{ stats.setAtkFinalRate }}%</span>
+        <span v-if="stats.setCritFinalRate" class="set-chip">최종크리율 +{{ stats.setCritFinalRate }}%</span>
+        <span v-if="stats.setCooldown"      class="set-chip">쿨타임 -{{ stats.setCooldown }}초</span>
+        <span v-if="stats.setEvasion"       class="set-chip">회피 {{ stats.setEvasion }}%</span>
       </div>
     </div>
 
@@ -403,7 +422,8 @@
       simJob:      '',
       activeCat:   '전체',
       stats: { atkMin:0,atkMax:0,effAtkMin:0,effAtkMax:0,jobDmgMul:1,
-               hpMax:0,regen:0,crit:0,critDmg:0,criConvert:0,criCap:5 },
+               hpMax:0,regen:0,crit:0,critDmg:0,criConvert:0,criCap:5,
+               setAtkFinalRate:0,setCritFinalRate:0,setCooldown:0,setEvasion:0 },
       calcTimer:   null,
       equipCats:   EQUIP_CATS,
       specialCats: SPECIAL_CATS,
@@ -561,17 +581,21 @@
           .then(function (data) {
             if (!data.error) {
               vm.stats = {
-                atkMin:     data.atkMin     || 0,
-                atkMax:     data.atkMax     || 0,
-                effAtkMin:  data.effAtkMin  || 0,
-                effAtkMax:  data.effAtkMax  || 0,
-                jobDmgMul:  data.jobDmgMul  || 1,
-                hpMax:      data.hpMax      || 0,
-                regen:      data.regen      || 0,
-                crit:       data.crit       || 0,
-                critDmg:    data.critDmg    || 0,
-                criConvert: data.criConvert || 0,
-                criCap:     data.criCap     || 5,
+                atkMin:          data.atkMin          || 0,
+                atkMax:          data.atkMax          || 0,
+                effAtkMin:       data.effAtkMin       || 0,
+                effAtkMax:       data.effAtkMax       || 0,
+                jobDmgMul:       data.jobDmgMul       || 1,
+                hpMax:           data.hpMax           || 0,
+                regen:           data.regen           || 0,
+                crit:            data.crit            || 0,
+                critDmg:         data.critDmg         || 0,
+                criConvert:      data.criConvert      || 0,
+                criCap:          data.criCap          || 5,
+                setAtkFinalRate: data.setAtkFinalRate || 0,
+                setCritFinalRate:data.setCritFinalRate|| 0,
+                setCooldown:     data.setCooldown     || 0,
+                setEvasion:      data.setEvasion      || 0,
               };
               vm.hunterGrade = data.hunterGrade || vm.hunterGrade;
             }


### PR DESCRIPTION
## Summary

- **아이템 시뮬레이션 3종 버그 수정**: 헌터랭크 F 고정 → DB 직접 조회로 캐시 의존 제거, 레벨 기반 스탯 `calcBase*` 공식 적용, 세트효과/어둠사냥꾼/헬너프 적용 순서를 `calcUserBattleContext` 와 동일하게 정렬
- **equip_sim_view.jsp**: 세트 최종공격률/크리율/쿨타임/회피 효과 UI 추가
- **구매/판매 PK 충돌 방지**: 콤마 다중구매·다중판매 시 `ThreadLocal` 로 비용 누적 후 `insertPointRank` 1회만 호출, 동시 중복 요청 차단 (`tryAcquireUserActionLock`)
- **신규**: `sellMultiItems` (콤마 기반 다중판매) 추가

## Test plan

- [ ] 아이템 시뮬 페이지에서 헌터 랭크가 올바르게 표시되는지 확인
- [ ] 레벨별 능력치가 실제 전투 ctx 값과 일치하는지 확인
- [ ] 세트 아이템 장착 시 세트효과 바가 표시되는지 확인
- [ ] `/구매 아이템1,아이템2` 다중구매 시 `TBOT_POINT_RANK` PK 충돌 없이 단일 row 삽입 확인
- [ ] `/판매 아이템1,아이템2` 다중판매 시 동일하게 단일 row 삽입 확인
- [ ] 동시 중복 요청 시 "처리 중입니다" 메시지 반환 확인

https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD)_