### PR TITLE
fix: 고레벨/곰직업 HP int 오버플로우 수정

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -598,7 +598,7 @@ public class BossAttackController {
 	        int atkSum = atkMin+atkMax;
 	        int critMultiplier = baseCritDmg + mktCritDmg;
 
-	        hpMax = hpMax + (atkSum * critMultiplier/100);
+	        hpMax = (int) Math.min((long)hpMax + (long)atkSum * critMultiplier / 100, Integer.MAX_VALUE);
 
 	        // 공격력은 의미 없음 → HP 기반으로 통일
 	        atkMin = hpMax;
@@ -612,11 +612,11 @@ public class BossAttackController {
 	        
 	    }
 
-	    int hpMaxBonus = (hpMax * (ctx.mktHpMaxRate)) /100;
+	    int hpMaxBonus = (int)((long)hpMax * ctx.mktHpMaxRate / 100);
 	    hpMax += hpMaxBonus;
-	    int atkMinBonus = (atkMin * (ctx.mktAtkMaxRate)) /100;
+	    int atkMinBonus = (int)((long)atkMin * ctx.mktAtkMaxRate / 100);
 	    atkMin += atkMinBonus;
-	    int atkMaxBonus = (atkMax * (ctx.mktAtkMaxRate)) /100;
+	    int atkMaxBonus = (int)((long)atkMax * ctx.mktAtkMaxRate / 100);
 	    atkMax += atkMaxBonus;
 	    
 	    int crit =baseCrit + mktCrit;
@@ -683,8 +683,8 @@ public class BossAttackController {
 	    }
 	    // ── 세트 효과: 최종 비율 보너스 (헬너프 포함 최종 수치 기준) ──────────────
 	    if (setAtkFinalRate > 0) {
-	        atkMin += (int) Math.round(atkMin * setAtkFinalRate / 100.0);
-	        atkMax += (int) Math.round(atkMax * setAtkFinalRate / 100.0);
+	        atkMin += (int) Math.round((long)atkMin * setAtkFinalRate / 100.0);
+	        atkMax += (int) Math.round((long)atkMax * setAtkFinalRate / 100.0);
 	    }
 	    if (setCritFinalRate > 0) {
 	        crit += (int) Math.round(crit * setCritFinalRate / 100.0);


### PR DESCRIPTION
## Summary

- 레벨 409 이상 / 곰 직업에서 HP가 ~2800만 도달 시 음수로 전환되는 오버플로우 버그 수정
- Java `int × int` 중간 연산이 21억(Integer.MAX_VALUE)을 초과해 발생하는 문제로, `long` 캐스팅으로 해결

## 수정 위치 (4곳)

| 위치 | 기존 | 수정 |
|------|------|------|
| 곰 직업 HP 계산 | `atkSum * critMultiplier / 100` | `(long)atkSum * critMultiplier / 100` |
| HP 최대치 비율 보너스 | `hpMax * mktHpMaxRate` | `(long)hpMax * mktHpMaxRate` |
| ATK 비율 보너스 (×2) | `atkMin/Max * mktAtkMaxRate` | `(long)atkMin/Max * mktAtkMaxRate` |
| 세트 최종공격률 (×2) | `atkMin/Max * setAtkFinalRate` | `(long)atkMin/Max * setAtkFinalRate` |

## Test plan

- [ ] 레벨 409 이상 곰 직업 유저 공격 시 HP가 정상 표시되는지 확인
- [ ] HP 2800만 이상에서 오버플로우 없이 정상 계산되는지 확인
- [ ] 다른 직업(헌터, 검성 등) 스탯에 영향 없는지 확인

https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD)_