### PR TITLE
feat: 장비랭킹 배치캐시 + 헬보스 도전시 스페셜타임 표기

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -4366,6 +4366,29 @@ public class BossAttackController {
 
 	    return result;
 	}
+
+	/** 현재 스페셜타임 진행중 메시지 반환 (없으면 빈 문자열). S3Controller 등 외부 호출용. */
+	public String getActiveSpecialTimeMsg() {
+	    try {
+	        long nowMs = System.currentTimeMillis();
+	        HashMap<String,Object> activeBuff = (nowMs - SPECIAL_BUFF_CACHE_TS < SPECIAL_BUFF_CACHE_TTL_MS)
+	                ? SPECIAL_BUFF_CACHE : botNewService.selectActiveSpecialBuff();
+	        if (activeBuff == null) return "";
+	        String fc  = Objects.toString(activeBuff.get("FLAG_CODE"), "");
+	        String et  = Objects.toString(activeBuff.get("EFFECT_TYPE"), "");
+	        double ev  = activeBuff.get("EFFECT_VALUE") != null
+	                ? Double.parseDouble(activeBuff.get("EFFECT_VALUE").toString()) : 0;
+	        java.util.Date endT = (java.util.Date) activeBuff.get("END_TIME");
+	        String endStr = endT != null
+	                ? endT.toInstant().atZone(ZoneId.systemDefault())
+	                    .toLocalDateTime()
+	                    .format(DateTimeFormatter.ofPattern("HH:mm"))
+	                : "?";
+	        return "✨스페셜타임 진행중! [" + buildBuffDescription(fc, et, ev) + ", " + endStr + "까지]";
+	    } catch (Exception ignore) {
+	        return "";
+	    }
+	}
 	
 	private int randomDuration(double effectValue) {
 

--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -115,6 +115,10 @@ public class BossAttackController {
 	private static volatile long SPECIAL_BUFF_CACHE_TS = 0L;
 	private static final long SPECIAL_BUFF_CACHE_TTL_MS = 15_000L;
 
+	// 장비랭킹 배치 캐시 (1시간마다 크론으로 갱신)
+	private static volatile List<HashMap<String,Object>> EQUIP_RANK_CACHE = null;
+	private static volatile long EQUIP_RANK_CACHE_TS = 0L;
+
 	// 누적SP 1위 캐시 (1시간마다 갱신, 가방 최대금액 계산용)
 	private static volatile long TOP1_SP_CACHE = 0L;
 	private static volatile long TOP1_SP_CACHE_TS = 0L;
@@ -2163,8 +2167,28 @@ public class BossAttackController {
 		        return userName + "님, [곰]은 상급악마를 공격할 수 없습니다.";
 		    botNewService.closeOngoingBattleTx(userName, roomName);
 		    botNewService.updateUserTargetMonTx(userName, roomName, 99);
-		    return userName + "님, 공격 타겟을 [상급악마](MON_NO=99) 으로 설정했습니다." + NL
+		    // 현재 스페셜타임 정보 추가
+		    String hellTargetMsg = userName + "님, 공격 타겟을 [상급악마](MON_NO=99) 으로 설정했습니다." + NL
 		         + "※ /ㄱ 으로 헬보스를 공격합니다.";
+		    try {
+		        long nowMs2 = System.currentTimeMillis();
+		        HashMap<String,Object> spBuff = (nowMs2 - SPECIAL_BUFF_CACHE_TS < SPECIAL_BUFF_CACHE_TTL_MS)
+		                ? SPECIAL_BUFF_CACHE : botNewService.selectActiveSpecialBuff();
+		        if (spBuff != null) {
+		            String fc   = Objects.toString(spBuff.get("FLAG_CODE"), "");
+		            String et   = Objects.toString(spBuff.get("EFFECT_TYPE"), "");
+		            double ev   = spBuff.get("EFFECT_VALUE") != null
+		                    ? Double.parseDouble(spBuff.get("EFFECT_VALUE").toString()) : 0;
+		            java.util.Date endT = (java.util.Date) spBuff.get("END_TIME");
+		            String endStr = endT != null
+		                    ? endT.toInstant().atZone(java.time.ZoneId.systemDefault())
+		                        .toLocalDateTime()
+		                        .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm"))
+		                    : "?";
+		            hellTargetMsg += NL + "✨스페셜타임 진행중! [" + buildBuffDescription(fc, et, ev) + ", " + endStr + "까지]";
+		        }
+		    } catch (Exception ignore) {}
+		    return hellTargetMsg;
 		}
 
 		Monster m = input.matches("\\d+")
@@ -8980,10 +9004,83 @@ public class BossAttackController {
 	@ResponseBody
 	@GetMapping("/api/equip-rank")
 	public Object getEquipRank() {
-	    return Collections.singletonMap("error", "현재 서비스 점검 중입니다.");
+	    if (EQUIP_RANK_CACHE == null || EQUIP_RANK_CACHE.isEmpty()) {
+	        return Collections.singletonMap("error", "데이터 준비 중입니다. 잠시 후 다시 시도해주세요.");
+	    }
+	    HashMap<String, Object> resp = new HashMap<>();
+	    resp.put("list", EQUIP_RANK_CACHE);
+	    resp.put("cachedAt", EQUIP_RANK_CACHE_TS);
+	    return resp;
 	}
+
+	/** 크론 배치용: 장비랭킹 캐시 갱신 (1시간마다 호출) */
+	public void refreshEquipRankCache() {
+	    List<HashMap<String, Object>> users;
+	    try {
+	        users = botNewService.selectAllUsersForRank();
+	    } catch (Exception e) {
+	        System.out.println("[CRON-equip-rank] 유저 목록 조회 실패: " + e.getMessage());
+	        return;
+	    }
+
+	    List<HashMap<String, Object>> result = new ArrayList<>();
+	    for (HashMap<String, Object> row : users) {
+	        String uName = Objects.toString(row.get("USER_NAME"), "");
+	        if (uName.isEmpty()) continue;
+	        HashMap<String, Object> ctxMap = new HashMap<>();
+	        ctxMap.put("userName", uName);
+	        ctxMap.put("roomName", "");
+	        UserBattleContext ctx;
+	        try {
+	            ctx = calcUserBattleContext(ctxMap);
+	        } catch (Exception e) { continue; }
+	        if (!ctx.success) continue;
+
+	        int lv = ctx.user != null ? ctx.user.lv : 0;
+	        int bossBonus = 0;
+	        boolean has7009 = ctx.ownedBossItems.contains(7009);
+	        boolean has7013 = ctx.ownedBossItems.contains(7013);
+	        if (has7009) bossBonus += Math.min(lv, 300) * 150;
+	        if (has7013) bossBonus += 30 * 500;
+
+	        List<String> setDesc = new ArrayList<>();
+	        if (ctx.setAtkFinalRate  > 0) setDesc.add("ATK+" + ctx.setAtkFinalRate + "%");
+	        if (ctx.setCritFinalRate > 0) setDesc.add("크리+" + ctx.setCritFinalRate + "%");
+	        if (ctx.setCooldownReduce> 0) setDesc.add("쿨-"  + ctx.setCooldownReduce + "s");
+	        if (ctx.setEvasionRate   > 0) setDesc.add("회피+" + ctx.setEvasionRate + "%");
+	        if (ctx.activeSetSpecials != null) {
+	            for (String sp : ctx.activeSetSpecials) setDesc.add(sp.replace("SPECIAL_", ""));
+	        }
+
+	        HashMap<String, Object> entry = new HashMap<>();
+	        entry.put("userName",   uName);
+	        entry.put("lv",         lv);
+	        entry.put("atkMin",     ctx.atkMin);
+	        entry.put("atkMax",     ctx.atkMax);
+	        entry.put("crit",       ctx.crit);
+	        entry.put("critDmg",    ctx.critDmg);
+	        entry.put("darkAtkMin", ctx.dropAtkMin);
+	        entry.put("darkAtkMax", ctx.dropAtkMax);
+	        entry.put("setInfo",    String.join(" / ", setDesc));
+	        entry.put("bossBonus",  bossBonus);
+	        entry.put("has7009",    has7009);
+	        entry.put("has7013",    has7013);
+	        entry.put("bossEstMin", ctx.atkMin + ctx.dropAtkMin + bossBonus);
+	        entry.put("bossEstMax", ctx.atkMax + ctx.dropAtkMax + bossBonus);
+	        result.add(entry);
+	    }
+
+	    result.sort((a, b) -> Integer.compare(
+	        b.get("bossEstMax") != null ? ((Number) b.get("bossEstMax")).intValue() : 0,
+	        a.get("bossEstMax") != null ? ((Number) a.get("bossEstMax")).intValue() : 0
+	    ));
+	    EQUIP_RANK_CACHE = result;
+	    EQUIP_RANK_CACHE_TS = System.currentTimeMillis();
+	    System.out.println("[CRON-equip-rank] 갱신 완료: " + result.size() + "명");
+	}
+
 	@SuppressWarnings("unused")
-	private Object getEquipRankDisabled() {
+	private Object getEquipRankLegacy() {
 	    List<HashMap<String, Object>> users;
 	    try {
 	        users = botNewService.selectAllUsersForRank();

--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -567,6 +567,12 @@ public class BossAttackS3Controller {
                .append(" (").append(String.format("%.1f", hpPct)).append("%)").append(NL);
         }
 
+        // 스페셜타임 진행중이면 표기
+        String specialTimeMsg = bossAttackController.getActiveSpecialTimeMsg();
+        if (!specialTimeMsg.isEmpty()) {
+            msg.append(specialTimeMsg).append(NL);
+        }
+
         return msg.toString().trim();
     }
 

--- a/src/main/java/my/prac/api/loa/controller/LoaChatController.java
+++ b/src/main/java/my/prac/api/loa/controller/LoaChatController.java
@@ -300,6 +300,14 @@ public class LoaChatController {
 				}
 			}
 			break;
+		case "c4":
+			// 장비랭킹 캐시 갱신 (1시간마다 호출)
+			try {
+				boss.refreshEquipRankCache();
+			} catch (Exception e1) {
+				e1.printStackTrace();
+			}
+			break;
 		case "test":
 			try {
 				market.search_c2();

--- a/src/main/webapp/WEB-INF/view/nonsession/loa/equip_rank_view.jsp
+++ b/src/main/webapp/WEB-INF/view/nonsession/loa/equip_rank_view.jsp
@@ -68,7 +68,9 @@ td.left  { text-align: left; }
 <%@ include file="_loa_nav.jsp" %>
 <div id="app" class="container">
   <h1>🔬 장비 랭킹</h1>
-  <p class="subtitle">직업 배율 미적용 · 장비+레벨 기준 순수 스탯 비교 (어둠/보스템 맥스치 반영)</p>
+  <p class="subtitle">직업 배율 미적용 · 장비+레벨 기준 순수 스탯 비교 (어둠/보스템 맥스치 반영)
+    <span v-if="cachedAt"> · 기준: {{ cachedAtStr }}</span>
+  </p>
 
   <div class="toolbar">
     <button @click="load" :disabled="loading">{{ loading ? '로딩 중...' : '새로고침' }}</button>
@@ -139,6 +141,7 @@ new Vue({
     loading: false,
     error: '',
     rows: [],
+    cachedAt: null,
     search: '',
     sortKey: 'bossEstMax',
     sortAsc: false,
@@ -157,6 +160,11 @@ new Vue({
         return asc ? va - vb : vb - va;
       });
     },
+    cachedAtStr() {
+      if (!this.cachedAt) return '';
+      const d = new Date(this.cachedAt);
+      return d.toLocaleString('ko-KR', { hour12: false });
+    },
   },
   methods: {
     load() {
@@ -165,7 +173,7 @@ new Vue({
         .then(r => r.json())
         .then(d => {
           if (d.error) { this.error = d.error; }
-          else { this.rows = d; }
+          else { this.rows = d.list || []; this.cachedAt = d.cachedAt || null; }
         })
         .catch(() => { this.error = '서버 오류가 발생했습니다.'; })
         .finally(() => { this.loading = false; });


### PR DESCRIPTION
[1] 장비랭킹 1시간 배치 캐시
- /loa/cron/c4 호출 시 전체 유저 장비스탯 계산 후 정적 캐시 저장
- /api/equip-rank 는 캐시된 데이터만 반환 (DB 실시간 조회 없음)
- API 응답에 cachedAt(갱신시각) 포함, view에서 '기준: HH:mm' 표시
- 캐시 없을 때 '데이터 준비 중' 안내

[2] 헬보스 도전시 스페셜타임 표기
- /ㄷ 99(상급악마) 타겟 설정 응답에 현재 진행 중인 스페셜타임 추가
- 스페셜타임 없으면 기존 메시지 그대로