### PR TITLE
feat: 장비랭킹 개선 - 활성유저/직업null/헬모드기준/너프율 컬럼

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -353,7 +353,15 @@ public class BossAttackController {
 	        ctx.lifetimeSpStr = "";
 	    }
 
-	    final String job = ctx.job;
+	    String job = ctx.job;
+
+	    // _noJobBonus: 직업 보너스 무시 (랭킹 배치용 — 공평한 순수 장비 비교)
+	    boolean noJobBonus = Boolean.TRUE.equals(map.get("_noJobBonus"));
+	    if (noJobBonus) job = "";
+
+	    // _forceHell: 헬모드 강제 적용 (랭킹 배치용 — 헬너프 포함 기준)
+	    boolean forceHell = Boolean.TRUE.equals(map.get("_forceHell"));
+	    if (forceHell) u.nightmareYn = 2;
 
 	    // 1~2) 인벤토리 버프 캐시 (TTL 60초, 인벤토리 변경 시 invalidateInvBuff로 무효화)
 	    HashMap<String,Object> invBuffData = getInvBuffCached(targetUser);
@@ -637,6 +645,7 @@ public class BossAttackController {
 	    if(u.nightmareYn==2) {
 	    	double hellMult = MiniGameUtil.getHellNerfMult(ctx.hunterGrade);
 	    	if (ctx.ownedBossItems.contains(7007)) hellMult = Math.max(0.0, hellMult + 0.03);
+	    	ctx.hellNerfRate = hellMult;
 
 	    	hellNerfAtkMin = Math.max(0, (int) Math.round(atkMin   * (1-hellMult) ));
 	    	hellNerfAtkMax = Math.max(0, (int) Math.round(atkMax   * (1-hellMult) ));
@@ -9051,8 +9060,11 @@ public class BossAttackController {
 	        String uName = Objects.toString(row.get("USER_NAME"), "");
 	        if (uName.isEmpty()) continue;
 	        HashMap<String, Object> ctxMap = new HashMap<>();
-	        ctxMap.put("userName", uName);
-	        ctxMap.put("roomName", "");
+	        ctxMap.put("userName",    uName);
+	        ctxMap.put("roomName",    "");
+	        ctxMap.put("_rankMode",   Boolean.TRUE);  // GP/hpCur 쿼리 스킵
+	        ctxMap.put("_noJobBonus", Boolean.TRUE);  // 직업 보너스 제외 (공평 비교)
+	        ctxMap.put("_forceHell",  Boolean.TRUE);  // 헬모드 기준 너프 적용
 	        UserBattleContext ctx;
 	        try {
 	            ctx = calcUserBattleContext(ctxMap);
@@ -9075,21 +9087,25 @@ public class BossAttackController {
 	            for (String sp : ctx.activeSetSpecials) setDesc.add(sp.replace("SPECIAL_", ""));
 	        }
 
+	        // 헬너프율: 백분율 정수 (예: 5 → "5%")
+	        int hellNerfPct = (int) Math.round(ctx.hellNerfRate * 100);
+
 	        HashMap<String, Object> entry = new HashMap<>();
-	        entry.put("userName",   uName);
-	        entry.put("lv",         lv);
-	        entry.put("atkMin",     ctx.atkMin);
-	        entry.put("atkMax",     ctx.atkMax);
-	        entry.put("crit",       ctx.crit);
-	        entry.put("critDmg",    ctx.critDmg);
-	        entry.put("darkAtkMin", ctx.dropAtkMin);
-	        entry.put("darkAtkMax", ctx.dropAtkMax);
-	        entry.put("setInfo",    String.join(" / ", setDesc));
-	        entry.put("bossBonus",  bossBonus);
-	        entry.put("has7009",    has7009);
-	        entry.put("has7013",    has7013);
-	        entry.put("bossEstMin", ctx.atkMin + ctx.dropAtkMin + bossBonus);
-	        entry.put("bossEstMax", ctx.atkMax + ctx.dropAtkMax + bossBonus);
+	        entry.put("userName",    uName);
+	        entry.put("lv",          lv);
+	        entry.put("atkMin",      ctx.atkMin);
+	        entry.put("atkMax",      ctx.atkMax);
+	        entry.put("crit",        ctx.crit);
+	        entry.put("critDmg",     ctx.critDmg);
+	        entry.put("darkAtkMin",  ctx.dropAtkMin);
+	        entry.put("darkAtkMax",  ctx.dropAtkMax);
+	        entry.put("setInfo",     String.join(" / ", setDesc));
+	        entry.put("bossBonus",   bossBonus);
+	        entry.put("has7009",     has7009);
+	        entry.put("has7013",     has7013);
+	        entry.put("bossEstMin",  ctx.atkMin + ctx.dropAtkMin + bossBonus);
+	        entry.put("bossEstMax",  ctx.atkMax + ctx.dropAtkMax + bossBonus);
+	        entry.put("hellNerfPct", hellNerfPct);
 	        result.add(entry);
 	    }
 

--- a/src/main/java/my/prac/core/game/dto/UserBattleContext.java
+++ b/src/main/java/my/prac/core/game/dto/UserBattleContext.java
@@ -71,11 +71,12 @@ public class UserBattleContext {
 
 	public String hunterGrade;
 
-	public int hellNerfAtkMin; 
-    public int hellNerfAtkMax; 
+	public int hellNerfAtkMin;
+    public int hellNerfAtkMax;
     public int hellNerfHp ;
-    public int hellNerfCrit; 
-    public int hellNerfCritDmg; 
+    public int hellNerfCrit;
+    public int hellNerfCritDmg;
+    public double hellNerfRate; // 헬너프 비율 (예: 0.05 = 5%)
     
 	// [OPT-HUNTER] attackInfo 에서 미리 조회한 dropsRows 공유용 (applyDropBonusToContext 중복 조회 방지)
 	public List<HashMap<String,Object>> preDropRows = null;

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -2210,7 +2210,7 @@
 	</delete>
 
 	<select id="selectAllUsersForRank" resultType="hashmap">
-		/* selectAllUsersForRank */
+		/* selectAllUsersForRank - 최근 3일 활성 유저만 */
 		SELECT USER_NAME, LV,
 		       NVL(ATK_MIN,   0) AS ATK_MIN,
 		       NVL(ATK_MAX,   0) AS ATK_MAX,
@@ -2220,6 +2220,7 @@
 		       NVL(NIGHTMARE_YN, 0) AS NIGHTMARE_YN
 		FROM TBOT_POINT_NEW_USER
 		WHERE LV > 0
+		  AND PROC_DATE > TRUNC(SYSDATE) - 3
 		ORDER BY USER_NAME
 	</select>
 

--- a/src/main/webapp/WEB-INF/view/nonsession/loa/equip_rank_view.jsp
+++ b/src/main/webapp/WEB-INF/view/nonsession/loa/equip_rank_view.jsp
@@ -62,13 +62,14 @@ td.left  { text-align: left; }
 .val-zero { color: #444; }
 
 .boss-badge { display: inline-block; background: #3d1515; color: #ff7675; border-radius: 4px; padding: 1px 5px; font-size: 0.7rem; margin-left: 2px; }
+.val-nerf { color: #fd9644; font-size: 0.78rem; }
 </style>
 </head>
 <body>
 <%@ include file="_loa_nav.jsp" %>
 <div id="app" class="container">
   <h1>🔬 장비 랭킹</h1>
-  <p class="subtitle">직업 배율 미적용 · 장비+레벨 기준 순수 스탯 비교 (어둠/보스템 맥스치 반영)
+  <p class="subtitle">직업 보너스 미적용 · 헬모드 너프 기준 · 최근 3일 활성 유저 (어둠/보스템 맥스치 반영)
     <span v-if="cachedAt"> · 기준: {{ cachedAtStr }}</span>
   </p>
 
@@ -96,7 +97,8 @@ td.left  { text-align: left; }
           <th @click="sort('darkAtkMax')">어둠 MAX <span class="arr">{{ arrow('darkAtkMax') }}</span></th>
           <th class="left" @click="sort('setInfo')">세트효과 <span class="arr">{{ arrow('setInfo') }}</span></th>
           <th @click="sort('bossBonus')">보스템 보너스 <span class="arr">{{ arrow('bossBonus') }}</span></th>
-          <th @click="sort('bossEstMax')">추정 MAX <span class="arr">{{ arrow('bossEstMax') }}</span></th>
+          <th @click="sort('bossEstMax')" class="sorted">추정 MAX <span class="arr">{{ arrow('bossEstMax') }}</span></th>
+          <th @click="sort('hellNerfPct')">헬너프율 <span class="arr">{{ arrow('hellNerfPct') }}</span></th>
         </tr>
       </thead>
       <tbody>
@@ -128,6 +130,10 @@ td.left  { text-align: left; }
             <span class="val-zero" v-if="r.bossBonus === 0">—</span>
           </td>
           <td class="right val-boss">{{ fmt(r.bossEstMax) }}</td>
+          <td class="right val-nerf">
+            <span v-if="r.hellNerfPct > 0">-{{ r.hellNerfPct }}%</span>
+            <span v-else class="val-zero">—</span>
+          </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
- selectAllUsersForRank: PROC_DATE > TRUNC(SYSDATE)-3 (최근 3일 활성유저)
- calcUserBattleContext: _noJobBonus 플래그 추가 (직업 보너스 전체 스킵)
- calcUserBattleContext: _forceHell 플래그 추가 (헬모드 너프 강제 적용)
- UserBattleContext: hellNerfRate 필드 추가
- refreshEquipRankCache: 위 플래그 모두 적용, hellNerfPct 컬럼 포함
- equip_rank_view.jsp: 헬너프율 컬럼 추가, subtitle 설명 수정