### PR TITLE
fix: 보스 보상 참여자 20명 제한 제거

### DIFF
--- a/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
@@ -183,7 +183,6 @@
 		     GROUP BY user_name
 		     ORDER BY SUM(atk_dmg) DESC
 		  ) A
-		 WHERE ROWNUM &lt;= 20
 	</select>
 
 	<!-- =====================================================
@@ -211,7 +210,6 @@
 		     GROUP BY user_name
 		     ORDER BY count(user_name) DESC
 		  ) A
-		 WHERE ROWNUM &lt;= 20
 	</select>
 
 	<!-- =====================================================


### PR DESCRIPTION
## Summary

- `selectHellTop3Contributors`, `selectHellEligibleContributors` 쿼리에서 `ROWNUM <= 20` 조건 제거
- 22명 참여 시 상위 20명만 보상/룰렛 대상이 되던 버그 수정 → 전체 참여자 모두 대상

## Test plan

- [ ] 21명 이상 참여한 보스 처치 후 전원 룰렛 대상에 포함되는지 확인
- [ ] 보상 지급(아이템/GP) 누락자 없는지 확인

https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD)_