### PR TITLE
refactor: openBag 쿼리 최적화 + 헬상자 SP PK 충돌 수정

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1191,13 +1191,14 @@ public class BossAttackController {
 	        }
 	    } catch (Exception ignore) {}
 
-	    // 91 / 92 / 93 각각 개수 조회
-	    int normalCount    = botNewService.selectBagCountByItemId(userName, roomName, 91);
-	    int nightmareCount = botNewService.selectBagCountByItemId(userName, roomName, 92);
-	    int hellCount      = botNewService.selectBagCountByItemId(userName, roomName, BAG_HELL_ITEM_ID);
-	    int hellEventCount = botNewService.selectBagCountByItemIdAndGainType(userName, roomName, BAG_HELL_ITEM_ID, "EVENT");
-	    int hellBossCount  = botNewService.selectBagCountByItemIdAndGainType(userName, roomName, BAG_HELL_ITEM_ID, "BOSS_HELL");
-	    int hellAttendCount = botNewService.selectBagCountByItemIdAndGainType(userName, roomName, BAG_HELL_ITEM_ID, "ATTEND");
+	    // ── 가방 개수 일괄 조회 (6 queries → 1) ───────────────────────────────────────
+	    HashMap<String,Object> bagCounts = botNewService.selectOpenBagCounts(userName);
+	    int normalCount     = bagCounts != null ? ((Number) bagCounts.getOrDefault("NORMAL_COUNT",      0)).intValue() : 0;
+	    int nightmareCount  = bagCounts != null ? ((Number) bagCounts.getOrDefault("NM_COUNT",          0)).intValue() : 0;
+	    int hellCount       = bagCounts != null ? ((Number) bagCounts.getOrDefault("HELL_COUNT",        0)).intValue() : 0;
+	    int hellEventCount  = bagCounts != null ? ((Number) bagCounts.getOrDefault("HELL_EVENT_COUNT",  0)).intValue() : 0;
+	    int hellBossCount   = bagCounts != null ? ((Number) bagCounts.getOrDefault("HELL_BOSS_COUNT",   0)).intValue() : 0;
+	    int hellAttendCount = bagCounts != null ? ((Number) bagCounts.getOrDefault("HELL_ATTEND_COUNT", 0)).intValue() : 0;
 	    int hellNoSpCount  = hellEventCount + hellBossCount + hellAttendCount; // SP 지급 제외 타입 합산
 	    int hellNormalCount = hellCount - hellNoSpCount;
 
@@ -1347,20 +1348,13 @@ public class BossAttackController {
 	    long top1Sp = getTop1SpCached();
 	    long spMin  = top1Sp > 0 ? top1Sp * 3 / 1000 : 1_000_000L;                          // 1등의 0.3%
 	    long spMax  = top1Sp > 0 ? Math.min(top1Sp / 100, 100_000_000_000L) : 5_000_000L;   // 1등의 1%, 최대 1000b
+	    SP hellSpLocal = new SP(0, ""); // SP 합산용 (루프 후 1회 INSERT)
 	    for (int i = 0; i < count; i++) {
 	        double roll = ThreadLocalRandom.current().nextDouble();
 	        if (!noSp && roll < 0.95) {
 	            // 95% → SP (HELL_BOX_SP CMD로 직접 저장)
 	            SP sp = pickBiasedSp(spMin, spMax);
-	            try {
-	                HashMap<String,Object> pr = new HashMap<>();
-	                pr.put("userName",  userName);
-	                pr.put("roomName",  roomName);
-	                pr.put("score",     sp.getValue());
-	                pr.put("scoreExt",  sp.getUnit());
-	                pr.put("cmd",       "HELL_BOX_SP");
-	                botNewService.insertPointRank(pr);
-	            } catch (Exception ignore) {}
+	            hellSpLocal.add(sp);
 	            totalSP.add(sp); // 표시용 누적
 	            detail.add("[지옥의유물상자]" + (i+1) + ": " + sp + "sp");
 	        } else {
@@ -1408,6 +1402,18 @@ public class BossAttackController {
 	                }
 	            }
 	        }
+	    }
+	    // ── SP 합산 후 1회 INSERT (동일금액 PK 충돌 방지) ─────────────────────
+	    if (hellSpLocal.getValue() != 0) {
+	        try {
+	            HashMap<String,Object> pr = new HashMap<>();
+	            pr.put("userName", userName);
+	            pr.put("roomName", roomName);
+	            pr.put("score",    hellSpLocal.getValue());
+	            pr.put("scoreExt", hellSpLocal.getUnit());
+	            pr.put("cmd",      "HELL_BOX_SP");
+	            botNewService.insertPointRank(pr);
+	        } catch (Exception ignore) {}
 	    }
 	}
 

--- a/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
@@ -238,6 +238,8 @@ public interface BotNewDAO {
     public int clearBlessYn(String userName) ;
     
     HashMap<String,Object> selectTodayBagCounts(HashMap<String,Object> param);
+    HashMap<String,Object> selectOpenBagCounts(String userName);
+
     int selectBagCountByItemId(HashMap<String,Object> param);
 
     int consumeBagBulkByItemId(HashMap<String,Object> param);

--- a/src/main/java/my/prac/core/prjbot/service/BotNewService.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotNewService.java
@@ -200,6 +200,8 @@ public interface BotNewService {
     public void clearBlessYn(String userName) ;
     
     HashMap<String,Object> selectTodayBagCounts(String userName, String roomName);
+    HashMap<String,Object> selectOpenBagCounts(String userName);
+
     int selectBagCountByItemId(String userName, String roomName, int itemId);
     int consumeBagBulkByItemIdTx(String userName, String roomName, int itemId, int count);
     int selectBagCountByItemIdAndGainType(String userName, String roomName, int itemId, String gainType);

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
@@ -670,6 +670,12 @@ public class BotNewServiceImpl implements BotNewService {
         return botNewDAO.selectTodayBagCounts(param);
     }
 
+    @Override
+    public HashMap<String,Object> selectOpenBagCounts(String userName) {
+        return botNewDAO.selectOpenBagCounts(userName);
+    }
+
+    @Override
     public int selectBagCountByItemId(String userName, String roomName, int itemId) {
 
         HashMap<String,Object> param = new HashMap<>();

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -1855,6 +1855,25 @@
 	       AND INSERT_DATE >= TRUNC(SYSDATE)
 	</select>
 
+
+	<!-- selectBagCountByItemId x6 → 단일 통합 쿼리 -->
+	<select id="selectOpenBagCounts" parameterType="String" resultType="hashmap">
+	    /* selectOpenBagCounts */
+	    SELECT
+	        NVL(SUM(CASE WHEN ITEM_ID = 91  AND NVL(GAIN_TYPE,'DROP') NOT IN ('DROP_OPEN_G','DROP_OPEN_P') THEN QTY ELSE 0 END), 0) AS NORMAL_COUNT,
+	        NVL(SUM(CASE WHEN ITEM_ID = 92  AND NVL(GAIN_TYPE,'DROP') NOT IN ('DROP_OPEN_G','DROP_OPEN_P') THEN QTY ELSE 0 END), 0) AS NM_COUNT,
+	        NVL(SUM(CASE WHEN ITEM_ID = 93  AND NVL(GAIN_TYPE,'DROP') NOT IN ('DROP_OPEN_G','DROP_OPEN_P') THEN QTY ELSE 0 END), 0) AS HELL_COUNT,
+	        NVL(SUM(CASE WHEN ITEM_ID = 93  AND GAIN_TYPE = 'EVENT'     THEN QTY ELSE 0 END), 0) AS HELL_EVENT_COUNT,
+	        NVL(SUM(CASE WHEN ITEM_ID = 93  AND GAIN_TYPE = 'BOSS_HELL' THEN QTY ELSE 0 END), 0) AS HELL_BOSS_COUNT,
+	        NVL(SUM(CASE WHEN ITEM_ID = 93  AND GAIN_TYPE = 'ATTEND'    THEN QTY ELSE 0 END), 0) AS HELL_ATTEND_COUNT
+	    FROM (
+	        SELECT ITEM_ID, GAIN_TYPE, QTY FROM TBOT_POINT_NEW_INVENTORY
+	         WHERE USER_NAME = #{userName} AND DEL_YN = '0' AND ITEM_ID IN (91, 92, 93)
+	        UNION ALL
+	        SELECT ITEM_ID, GAIN_TYPE, QTY FROM TBOT_POINT_NEW_INVENTORY_OLD
+	         WHERE USER_NAME = #{userName} AND DEL_YN = '0' AND ITEM_ID IN (91, 92, 93)
+	    )
+	</select>
 	<select id="selectBagCountByItemId"
 	        parameterType="hashmap"
 	        resultType="int">


### PR DESCRIPTION
[1] openBag SELECT 6회 → 1회 통합 (selectOpenBagCounts)
- NORMAL/NM/HELL/EVENT/BOSS_HELL/ATTEND 카운트를 단일 CASE-SUM 쿼리로 통합
- BotNewMapper, DAO, Service, ServiceImpl에 selectOpenBagCounts 추가

[2] openHellBag SP PK 충돌 수정
- 헬상자 N개 오픈 시 동일 금액 → 같은 초에 CMD=HELL_BOX_SP 중복 INSERT → PK 에러
- 루프 내 즉시 INSERT 제거, hellSpLocal에 합산 후 루프 종료 시 1회만 INSERT