### PR TITLE
fix: 91/92/93 가방 드랍 상한 및 구매가 고정

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1786,7 +1786,8 @@ public class BossAttackController {
 	    	return pickBiasedSp(300000, nmMax);
 	    }
 	    case	2:
-	    	break;
+	    	// 헬상자: 고정 상한 200b
+	    	return pickBiasedSp(1_000_000L, 20_000_000_000L);
 	    default:
 	    	break;
 	    }

--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1773,14 +1773,16 @@ public class BossAttackController {
 
 	private SP rollBagSpWithCeiling(int nightmareYn) {
 	    long top1Sp = getTop1SpCached();
-	    long top1Ceiling2 = top1Sp > 0 ? top1Sp / 500 : 0; // 1등 누적SP의 0.2%
 
 	    switch (nightmareYn) {
-	    case	0:
-	    	return pickBiasedSp(10000, top1Ceiling2 > 0 ? top1Ceiling2 : 1000000);
+	    case	0: {
+	    	// 일반가방: max = min(1등SP의 0.2%, 10b)
+	    	long nmMax = top1Sp > 0 ? Math.min(top1Sp / 500, 1_000_000_000L) : 1_000_000L;
+	    	return pickBiasedSp(10000, nmMax);
+	    }
 	    case	1: {
-	    	// 나메상자: max = 1등SP의 0.5%, 최대 10b (1_000_000_000 raw)
-	    	long nmMax = top1Sp > 0 ? Math.min(top1Sp / 200, 1_000_000_000L) : 100_000_000L;
+	    	// 나메상자: max = min(1등SP의 0.5%, 20b)
+	    	long nmMax = top1Sp > 0 ? Math.min(top1Sp / 200, 2_000_000_000L) : 100_000_000L;
 	    	return pickBiasedSp(300000, nmMax);
 	    }
 	    case	2:
@@ -1788,7 +1790,8 @@ public class BossAttackController {
 	    default:
 	    	break;
 	    }
-	    return pickBiasedSp(10000, top1Ceiling2 > 0 ? top1Ceiling2 : 1000000);
+	    long ceiling = top1Sp > 0 ? Math.min(top1Sp / 500, 1_000_000_000L) : 1_000_000L;
+	    return pickBiasedSp(10000, ceiling);
 	}
 
 	/* ===== Public APIs ===== */

--- a/src/main/java/my/prac/core/util/MiniGameUtil.java
+++ b/src/main/java/my/prac/core/util/MiniGameUtil.java
@@ -623,39 +623,27 @@ public class MiniGameUtil {
 	    return itemId >= 1001 && itemId <= 1100;
 	}
 
-	// ── 가방 상점 가격 (각 가방 최대 드랍치 × 2) ────────────────────────────
-	// 노말(91): max = top1Sp/500 (0.2%)  → 가격 = top1Sp/500*2 = top1Sp/250
-	// =====================================================
-	// 가방 상점 가격 공식 및 상한 (여기서 조정)
-	//   가격 = min(top1Sp / DIVISOR, MAX_RAW)
-	//   1 bsp = 100,000,000 raw
-	// =====================================================
-	/** 91 일반가방: top1/250, 상한 10 bsp */
-	public static final long BAG_PRICE_91_DIV = 250;
-	public static final long BAG_PRICE_91_MAX = 1_000_000_000L;   // 10 bsp
+	// ── 가방 상점 가격 ────────────────────────────────────────────────────────
+	// 91 일반가방: 고정 10b (1_000_000_000 raw)
+	// 92 나메가방: 고정 20b (2_000_000_000 raw)
+	// 93 헬가방  : 변동 min(top1Sp/50, 200b)
+	public static final long BAG_PRICE_91_FIXED = 1_000_000_000L;  // 10b 고정
+	public static final long BAG_PRICE_92_FIXED = 2_000_000_000L;  // 20b 고정
 
-	/** 92 나메가방: top1/100, 상한 20 bsp */
-	public static final long BAG_PRICE_92_DIV = 100;
-	public static final long BAG_PRICE_92_MAX = 2_000_000_000L;   // 20 bsp
-
-	/** 93 헬가방: top1/50, 상한 1000 bsp (변동가격 위주) */
+	/** 93 헬가방: top1/50, 상한 200b */
 	public static final long BAG_PRICE_93_DIV = 50;
-	public static final long BAG_PRICE_93_MAX = 100_000_000_000L; // 1000 bsp
+	public static final long BAG_PRICE_93_MAX = 20_000_000_000L;   // 200b
 
 	public static SP getBagPrice(int itemId, long top1SpRaw) {
-	    if (top1SpRaw <= 0) {
-	        // 기본값 (1등 데이터 없을 때)
-	        switch (itemId) {
-	            case 91: return SP.of(2_000_000L,      "");
-	            case 92: return SP.of(200_000_000L,    "");
-	            case 93: return SP.of(10_000_000_000L, "");
-	            default: return SP.of(0, "");
-	        }
-	    }
 	    switch (itemId) {
-	        case 91: return SP.fromSp(Math.max(Math.min(top1SpRaw / BAG_PRICE_91_DIV, BAG_PRICE_91_MAX), 1));
-	        case 92: return SP.fromSp(Math.max(Math.min(top1SpRaw / BAG_PRICE_92_DIV, BAG_PRICE_92_MAX), 1));
-	        case 93: return SP.fromSp(Math.max(Math.min(top1SpRaw / BAG_PRICE_93_DIV, BAG_PRICE_93_MAX), 1));
+	        case 91: return SP.fromSp(BAG_PRICE_91_FIXED);
+	        case 92: return SP.fromSp(BAG_PRICE_92_FIXED);
+	        case 93: {
+	            long price = top1SpRaw > 0
+	                ? Math.min(top1SpRaw / BAG_PRICE_93_DIV, BAG_PRICE_93_MAX)
+	                : 10_000_000_000L;
+	            return SP.fromSp(Math.max(price, 1));
+	        }
 	        default: return SP.of(0, "");
 	    }
 	}

--- a/src/main/java/my/prac/core/util/MiniGameUtil.java
+++ b/src/main/java/my/prac/core/util/MiniGameUtil.java
@@ -623,27 +623,19 @@ public class MiniGameUtil {
 	    return itemId >= 1001 && itemId <= 1100;
 	}
 
-	// ── 가방 상점 가격 ────────────────────────────────────────────────────────
-	// 91 일반가방: 고정 10b (1_000_000_000 raw)
-	// 92 나메가방: 고정 20b (2_000_000_000 raw)
-	// 93 헬가방  : 변동 min(top1Sp/50, 200b)
-	public static final long BAG_PRICE_91_FIXED = 1_000_000_000L;  // 10b 고정
-	public static final long BAG_PRICE_92_FIXED = 2_000_000_000L;  // 20b 고정
-
-	/** 93 헬가방: top1/50, 상한 200b */
-	public static final long BAG_PRICE_93_DIV = 50;
-	public static final long BAG_PRICE_93_MAX = 20_000_000_000L;   // 200b
+	// ── 가방 상점 가격 (고정가) ───────────────────────────────────────────────
+	// 91 일반가방: 고정 10b  (1_000_000_000 raw)
+	// 92 나메가방: 고정 20b  (2_000_000_000 raw)
+	// 93 헬가방  : 고정 200b (20_000_000_000 raw)
+	public static final long BAG_PRICE_91_FIXED  = 1_000_000_000L;   // 10b
+	public static final long BAG_PRICE_92_FIXED  = 2_000_000_000L;   // 20b
+	public static final long BAG_PRICE_93_FIXED  = 20_000_000_000L;  // 200b
 
 	public static SP getBagPrice(int itemId, long top1SpRaw) {
 	    switch (itemId) {
 	        case 91: return SP.fromSp(BAG_PRICE_91_FIXED);
 	        case 92: return SP.fromSp(BAG_PRICE_92_FIXED);
-	        case 93: {
-	            long price = top1SpRaw > 0
-	                ? Math.min(top1SpRaw / BAG_PRICE_93_DIV, BAG_PRICE_93_MAX)
-	                : 10_000_000_000L;
-	            return SP.fromSp(Math.max(price, 1));
-	        }
+	        case 93: return SP.fromSp(BAG_PRICE_93_FIXED);
 	        default: return SP.of(0, "");
 	    }
 	}


### PR DESCRIPTION
## Summary
- 91 일반가방: 드랍 상한 10b 적용, 구매가 고정 10b
- 92 나메가방: 드랍 상한 20b 적용, 구매가 고정 20b
- 93 헬가방: 드랍 상한 200b 고정, 구매가 고정 200b (top1Sp 쿼리 미사용)

https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6YNnjQgBDjrKs8FQtfjMD)_