### PR TITLE
fix: attack stat calculation with BATTLE_JOB monthly data

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -2371,7 +2371,8 @@ public class BossAttackController {
 	    
 	    
 	 // === NEW: 일별 공격 통계 (어제 자정까지) ===
-	    Date firstAttackDay = null;
+	    // 시작일: TBOT_POINT_NEW_USER.INSERT_DATE 사용
+	    Date firstAttackDay = (u.insertDate != null) ? truncateToDate(new Date(u.insertDate.getTime())) : null;
 	    Date maxAttackDay   = null;
 	    int  maxAttackCnt   = 0;
 	    int  avgAttackPerDay = 0;
@@ -2403,24 +2404,13 @@ public class BossAttackController {
 
 	                if (day == null) continue;
 
-	                // 최초 공격일
-	                if (firstAttackDay == null) {
-	                    firstAttackDay = day;
-	                }
-
-	                // 최대 공격일
-	                if (cnt > maxAttackCnt) {
-	                    maxAttackCnt = cnt;
-	                    maxAttackDay = day;
-	                }
-
-	                // ★ 오늘 공격
-	                if (day.equals(today)) {
-	                    todayAttackCnt = cnt;
-	                } else {
-	                    // ★ 어제까지 누적/평균용
-	                    totalAtkBeforeToday += cnt;
-	                    activeDays++;
+	                // DATA_TYPE: D=일별(BATTLE_LOG), M=월별(BATTLE_JOB)
+	                boolean isDaily = "D".equals(row.get("DATA_TYPE"));
+	                // 최대/평균/오늘은 일별(D) 데이터만 사용 (월 합계 M 제외)
+	                if (isDaily) {
+	                    if (cnt > maxAttackCnt) { maxAttackCnt = cnt; maxAttackDay = day; }
+	                    if (day.equals(today)) { todayAttackCnt = cnt; }
+	                    else { totalAtkBeforeToday += cnt; activeDays++; }
 	                }
 	            }
 

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -835,19 +835,23 @@
 	</select>
 	
 	<select id="selectDailyAttackCounts" parameterType="hashmap" resultType="hashmap">
-		/*selectDailyAttackCounts — BATTLE_JOB(2달 이전 월별) + BATTLE_LOG(최근 2달 일별) UNION ALL */
-		SELECT ATTACK_DAY, SUM(ATK_CNT) AS ATK_CNT FROM (
-		  /* 2달 이전: BATTLE_JOB 월별 집계 → 해당월 1일로 표현 */
+		/*selectDailyAttackCounts — BATTLE_JOB(2달 이전 월별 M) + BATTLE_LOG(최근 2달 일별 D) */
+		SELECT ATTACK_DAY, SUM(ATK_CNT) AS ATK_CNT,
+		       MAX(DATA_TYPE) AS DATA_TYPE
+		FROM (
+		  /* 2달 이전: BATTLE_JOB 월별 집계 → 해당월 1일, DATA_TYPE='M' */
 		  SELECT TRUNC(TO_DATE(STAT_YM,'YYYYMM'),'MM') AS ATTACK_DAY,
-		         SUM(ATTACK_CNT) AS ATK_CNT
+		         SUM(ATTACK_CNT) AS ATK_CNT,
+		         'M' AS DATA_TYPE
 		    FROM TBOT_POINT_NEW_BATTLE_JOB
 		   WHERE USER_NAME = #{userName}
 		     AND TO_DATE(STAT_YM,'YYYYMM') &lt; ADD_MONTHS(TRUNC(SYSDATE,'MM'), -1)
 		   GROUP BY TRUNC(TO_DATE(STAT_YM,'YYYYMM'),'MM')
 		  UNION ALL
-		  /* 최근 2달: BATTLE_LOG 일별 집계 */
+		  /* 최근 2달: BATTLE_LOG 일별 집계, DATA_TYPE='D' */
 		  SELECT TRUNC(INSERT_DATE) AS ATTACK_DAY,
-		         COUNT(1)            AS ATK_CNT
+		         COUNT(1)            AS ATK_CNT,
+		         'D' AS DATA_TYPE
 		    FROM TBOT_POINT_NEW_BATTLE_LOG
 		   WHERE USER_NAME = #{userName}
 		     AND INSERT_DATE &lt; SYSDATE


### PR DESCRIPTION
- selectDailyAttackCounts: add DATA_TYPE column (D=daily, M=monthly)
- firstAttackDay: use TBOT_POINT_NEW_USER.INSERT_DATE (not first row of data)
- maxAttackCnt/avgAttackPerDay/todayAttackCnt: only DATA_TYPE=D rows (BATTLE_JOB monthly totals no longer inflate max/avg)