### PR TITLE
feat: 헬보스 개선 3종 - INSERT_DATE 하한/excludedUsers 수정/체력3배+데미지20%

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -62,8 +62,8 @@ public class BossAttackS3Controller {
     /** 보스 치명 저항 (%) */
     static final int BOSS_CRIT_DEF_MIN   = 10,  BOSS_CRIT_DEF_MAX   = 30;
     /** 보스 최대 HP (raw) — 기존 대비 약 50% 감소 */
-    static final long BOSS_MAX_HP_MIN    = 37_500L;
-    static final long BOSS_MAX_HP_MAX    = 150_000L;
+    static final long BOSS_MAX_HP_MIN    = 112_500L;
+    static final long BOSS_MAX_HP_MAX    = 450_000L;
 
     /** 헬보스 보상 아이템 타입 */
     private static final String HELL_ITEM_TYPE = "BOSS_HELL";
@@ -470,7 +470,7 @@ public class BossAttackS3Controller {
         String dmgLimitMsg = "";
         
      // 보스 최대체력의 10% 이상 피해 제한
-        long maxDamageLimit = Math.max(1L, maxHp / 10);
+        long maxDamageLimit = Math.max(1L, maxHp / 5);
 
         if (totalDamage > maxDamageLimit) {
             long beforeLimit = totalDamage;
@@ -480,7 +480,7 @@ public class BossAttackS3Controller {
                     + SP.fromSp(beforeLimit)
                     + " → "
                     + SP.fromSp(totalDamage)
-                    + " (보스 최대체력 10% 제한)"
+                    + " (보스 최대체력 20% 제한)"
                     + NL;
         }
         
@@ -1013,10 +1013,17 @@ public class BossAttackS3Controller {
             for (HashMap<String, Object> row : eligibleFromDB)
                 noItemNames.add(row.get("USER_NAME").toString());
 
-            // 전체 참여자 중 7000번대 미소지자
+            // 아이템 2개 이상 보유자 전체 조회 (현재 보스 공격 여부 무관)
+            Set<String> twoItemOwners = new HashSet<>();
+            try {
+                List<String> owners = botS3Service.selectHellItemOwners();
+                if (owners != null) twoItemOwners.addAll(owners);
+            } catch (Exception ignore) {}
+
+            // 전체 활성 유저 중 아이템 2개 미만인 대상
             List<String> itemCandidates = new ArrayList<>();
             for (String uName : allNames) {
-                if (noItemNames.contains(uName)) itemCandidates.add(uName);
+                if (!twoItemOwners.contains(uName)) itemCandidates.add(uName);
             }
 
             if (itemCandidates.isEmpty()) {
@@ -1081,13 +1088,13 @@ public class BossAttackS3Controller {
                 msg.append(NL);
                 msg.append("당첨자 제외 전체 +0.2GP").append(NL);
 
-                // 보스드랍템 2개 보유자 목록
+                // 룰렛 제외자: 보스드랍템 2개 이상 보유자 (활성 유저 풀 기준)
                 List<String> excludedUsers = new ArrayList<>();
                 for (String uName : allNames) {
-                    if (!noItemNames.contains(uName)) excludedUsers.add(uName);
+                    if (twoItemOwners.contains(uName)) excludedUsers.add(uName);
                 }
                 if (!excludedUsers.isEmpty()) {
-                    msg.append(NL).append("(보스드랍템 2개 보유자)").append(NL);
+                    msg.append(NL).append("(룰렛 제외 - 보스드랍템 2개 이상 보유자)").append(NL);
                     for (String u : excludedUsers) msg.append(u).append(NL);
                 }
 

--- a/src/main/java/my/prac/core/prjbot/dao/BotS3DAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotS3DAO.java
@@ -29,7 +29,10 @@ public interface BotS3DAO {
 	/** [헬보스] 룰렛 대상 목록 (헬모드 kill + 최근 활동) */
 	List<String> selectHellLotteryPool();
 
-	/** [헬보스] 헬모드 일반 공격 시 INSERT_DATE 30초 감소 */
+	/** [헬보스] BOSS_HELL 아이템 2개 이상 보유자 목록 (룰렛 제외 대상) */
+	List<String> selectHellItemOwners();
+
+	/** [헬보스] 헬모드 일반 공격 시 INSERT_DATE 20초 감소 (현재시간 하한) */
 	int reduceHellBossInsertDate();
 
 	/** [헬보스] 마지막 처치된 보스 조회 (리워드 표시용) */

--- a/src/main/java/my/prac/core/prjbot/service/BotS3Service.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotS3Service.java
@@ -23,7 +23,10 @@ public interface BotS3Service {
 	/** [헬보스] 룰렛 대상 목록 (헬모드 kill + 최근 활동) */
 	List<String> selectHellLotteryPool();
 
-	/** [헬보스] 헬모드 일반 공격 시 INSERT_DATE 30초 감소 */
+	/** [헬보스] BOSS_HELL 아이템 2개 이상 보유자 목록 (룰렛 제외 대상) */
+	List<String> selectHellItemOwners();
+
+	/** [헬보스] 헬모드 일반 공격 시 INSERT_DATE 20초 감소 (현재시간 하한) */
 	void reduceHellBossInsertDate();
 
 	/** [헬보스] 마지막 처치 보스 + 보상 수령자 메시지 (보스 없을 때 표시용) */

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotS3ServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotS3ServiceImpl.java
@@ -58,6 +58,11 @@ public class BotS3ServiceImpl implements BotS3Service {
 	}
 
 	@Override
+	public List<String> selectHellItemOwners() {
+		return botS3DAO.selectHellItemOwners();
+	}
+
+	@Override
 	public void reduceHellBossInsertDate() {
 		botS3DAO.reduceHellBossInsertDate();
 	}

--- a/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
@@ -56,7 +56,7 @@
 	<update id="reduceHellBossInsertDate">
 		/* reduceHellBossInsertDate */
 		UPDATE TBOT_POINT_NEW_BOSS
-		   SET INSERT_DATE = INSERT_DATE - NUMTODSINTERVAL(30, 'SECOND')
+		   SET INSERT_DATE = GREATEST(SYSDATE, INSERT_DATE - NUMTODSINTERVAL(20, 'SECOND'))
 		 WHERE SEQ = (
 		     SELECT MAX(SEQ) FROM TBOT_POINT_NEW_BOSS WHERE END_YN = '0'
 		 )
@@ -320,6 +320,21 @@
 		     ORDER BY INSERT_DATE DESC
 		  )
 		 WHERE ROWNUM = 1
+	</select>
+
+	<!-- =====================================================
+	     [S3 헬보스] BOSS_HELL 아이템 2개 이상 보유자 조회
+	     - 아이템 룰렛 제외 대상 산정용
+	     ===================================================== -->
+	<select id="selectHellItemOwners" resultType="String">
+		/* selectHellItemOwners */
+		SELECT USER_NAME
+		  FROM TBOT_POINT_NEW_INVENTORY
+		 WHERE ITEM_ID BETWEEN 7000 AND 7999
+		   AND NVL(DEL_YN, '0') = '0'
+		   AND GAIN_TYPE = 'BOSS_HELL'
+		 GROUP BY USER_NAME
+		HAVING COUNT(1) >= 2
 	</select>
 
 	<!-- [S3 헬보스] 최근 200회 공격의 평균 데미지 -->


### PR DESCRIPTION
1. reduceHellBossInsertDate: GREATEST(SYSDATE, ...) 적용으로 현재시간 이하 방지, 30→20초
2. 아이템 보상 룰렛 제외자 수정:
   - 기존: allNames - noItemNames (보스 미공격자도 제외 표시됨 버그)
   - 변경: selectHellItemOwners로 BOSS_HELL 2개 이상 보유자만 정확히 제외
3. 보스 최대체력 3배 (37500~150000 → 112500~450000)
4. 데미지 제한 10% → 20%