### PR TITLE
fix: 가방열기 일괄처리 / 헬상자 SP 1000b 고정 / 감금스킬 임시 비활성화 / 대악마·마왕 10명+ 조건

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1189,59 +1189,42 @@ public class BossAttackController {
 	        return "방/유저 정보가 누락되었습니다.";
 	    }
 
-	    // ── 헬상자 pending 확인 (황금상자 일괄 처리) ───────────────────────────────────
+	    // ── 헬상자 pending 확인 (황금+플래티넘 전체 일괄 처리) ──────────────────────────
 	    try {
-	        HashMap<String,Object> pendingRow = botNewService.selectPendingHellBox(userName);
-	        if (pendingRow != null) {
-	            String gainType = Objects.toString(pendingRow.get("GAIN_TYPE"), "");
-	            boolean isGold  = "DROP_OPEN_G".equals(gainType);
-	            int pendingQty  = pendingRow.get("QTY") != null ? ((Number) pendingRow.get("QTY")).intValue() : 1;
-
-	            // 황금상자: 5% 진화 판정 (1번만), 나머지는 전부 일괄 개봉
-	            if (isGold && ThreadLocalRandom.current().nextDouble() < 0.05) {
-	                // 황금 → 플래티넘 진화
-	                botNewService.confirmPendingHellBox(userName);
-	                if (pendingQty > 1) {
-	                    HashMap<String,Object> goldRemain = new HashMap<>();
-	                    goldRemain.put("userName", userName); goldRemain.put("roomName", roomName);
-	                    goldRemain.put("itemId", 93); goldRemain.put("qty", pendingQty - 1);
-	                    goldRemain.put("delYn", "0"); goldRemain.put("gainType", "DROP_OPEN_G");
-	                    try { botNewService.insertInventoryLogTx(goldRemain); } catch (Exception ignore4) {}
-	                }
-	                HashMap<String,Object> platInv = new HashMap<>();
-	                platInv.put("userName", userName); platInv.put("roomName", roomName);
-	                platInv.put("itemId", 93); platInv.put("qty", 1);
-	                platInv.put("delYn", "0"); platInv.put("gainType", "DROP_OPEN_P");
-	                try { botNewService.insertInventoryLogTx(platInv); } catch (Exception ignore3) {}
-	                StringBuilder sb = new StringBuilder();
+	        List<HashMap<String,Object>> pendingGroups = botNewService.selectAllPendingHellBoxGrouped(userName);
+	        if (pendingGroups != null && !pendingGroups.isEmpty()) {
+	            int totalGold = 0, totalPlat = 0;
+	            for (HashMap<String,Object> pg : pendingGroups) {
+	                String gt = Objects.toString(pg.get("GAIN_TYPE"), "");
+	                int qty = pg.get("QTY") != null ? ((Number) pg.get("QTY")).intValue() : 0;
+	                if ("DROP_OPEN_G".equals(gt)) totalGold += qty;
+	                else if ("DROP_OPEN_P".equals(gt)) totalPlat += qty;
+	            }
+	            StringBuilder sb = new StringBuilder();
+	            // 황금 → 플래티넘 진화 (5%, 황금 있을 때만)
+	            if (totalGold > 0 && ThreadLocalRandom.current().nextDouble() < 0.05) {
+	                totalGold--;
+	                totalPlat++;
 	                sb.append(userName).append("님, ✨ 기적!! 황금 각인이 더욱 빛을 발합니다!!").append(NL);
 	                sb.append("━━━━━━━━━━━━").append(NL);
-	                sb.append("✨ 플래티넘로 진화하였습니다!! ✨").append(NL);
+	                sb.append("✨ 플래티넘으로 진화하였습니다!! ✨").append(NL);
 	                sb.append("━━━━━━━━━━━━").append(NL);
-	                sb.append("/가방열기 로 개봉하세요!");
-	                return sb.toString();
-	            } else {
-	                // 황금/플래티넘 일괄 개봉 (pendingQty개 전부)
-	                java.util.List<my.prac.core.util.MiniGameUtil.HellBoxEntry> pool =
-	                    isGold ? my.prac.core.util.MiniGameUtil.HELL_BOX_GOLD
-	                           : my.prac.core.util.MiniGameUtil.HELL_BOX_PLAT;
-	                String hellGainType = isGold ? "HELL_BOX_GOLD" : "HELL_BOX_PLAT";
-	                String tierLabel    = isGold ? "황금" : "플래티넘";
-	                StringBuilder sb = new StringBuilder();
-	                sb.append(userName).append("님, ✨ ").append(tierLabel).append("상자 ").append(pendingQty).append("개 개봉!").append(NL);
+	            }
+	            boolean platAchvDone = false;
+	            // 플래티넘 먼저 개봉
+	            if (totalPlat > 0) {
+	                sb.append(userName).append("님, ✨ 플래티넘상자 ").append(totalPlat).append("개 개봉!").append(NL);
 	                sb.append("━━━━━━━━━━━━").append(NL);
-	                boolean platAchvDone = false;
-	                for (int _i = 0; _i < pendingQty; _i++) {
+	                for (int _i = 0; _i < totalPlat; _i++) {
 	                    my.prac.core.util.MiniGameUtil.HellBoxEntry entry =
-	                        pool.get(ThreadLocalRandom.current().nextInt(pool.size()));
+	                        my.prac.core.util.MiniGameUtil.HELL_BOX_PLAT.get(ThreadLocalRandom.current().nextInt(my.prac.core.util.MiniGameUtil.HELL_BOX_PLAT.size()));
 	                    HashMap<String,Object> inv = new HashMap<>();
 	                    inv.put("userName", userName); inv.put("roomName", roomName);
 	                    inv.put("itemId", entry.itemId); inv.put("qty", entry.value);
-	                    inv.put("delYn", "0"); inv.put("gainType", hellGainType);
+	                    inv.put("delYn", "0"); inv.put("gainType", "HELL_BOX_PLAT");
 	                    try { botNewService.insertInventoryLogTx(inv); } catch (Exception ignore2) {}
 	                    sb.append("✨ ").append(entry.starsStr()).append(" ").append(entry.desc).append(" 획득!").append(NL);
-	                    // 플래티넘 첫 획득 업적 (1번만)
-	                    if (!isGold && !platAchvDone) {
+	                    if (!platAchvDone) {
 	                        try {
 	                            int alreadyHas = botNewService.selectPointRankCountByCmdUserInRoom(roomName, userName, "ACHV_PLAT_BOX_1");
 	                            if (alreadyHas == 0) {
@@ -1256,13 +1239,29 @@ public class BossAttackController {
 	                        } catch (Exception ignore3) {}
 	                    }
 	                }
-	                // 전체 soft-delete
-	                botNewService.confirmPendingHellBox(userName);
-	                invalidateInvBuff(userName);
 	                sb.append("━━━━━━━━━━━━").append(NL);
-	                sb.append(buildHellBoxStatSummary(userName));
-	                return sb.toString();
 	            }
+	            // 황금 개봉
+	            if (totalGold > 0) {
+	                sb.append(userName).append("님, ✨ 황금상자 ").append(totalGold).append("개 개봉!").append(NL);
+	                sb.append("━━━━━━━━━━━━").append(NL);
+	                for (int _i = 0; _i < totalGold; _i++) {
+	                    my.prac.core.util.MiniGameUtil.HellBoxEntry entry =
+	                        my.prac.core.util.MiniGameUtil.HELL_BOX_GOLD.get(ThreadLocalRandom.current().nextInt(my.prac.core.util.MiniGameUtil.HELL_BOX_GOLD.size()));
+	                    HashMap<String,Object> inv = new HashMap<>();
+	                    inv.put("userName", userName); inv.put("roomName", roomName);
+	                    inv.put("itemId", entry.itemId); inv.put("qty", entry.value);
+	                    inv.put("delYn", "0"); inv.put("gainType", "HELL_BOX_GOLD");
+	                    try { botNewService.insertInventoryLogTx(inv); } catch (Exception ignore2) {}
+	                    sb.append("✨ ").append(entry.starsStr()).append(" ").append(entry.desc).append(" 획득!").append(NL);
+	                }
+	                sb.append("━━━━━━━━━━━━").append(NL);
+	            }
+	            // 전체 pending 일괄 soft-delete
+	            botNewService.confirmAllPendingHellBoxes(userName);
+	            invalidateInvBuff(userName);
+	            sb.append(buildHellBoxStatSummary(userName));
+	            return sb.toString();
 	        }
 	    } catch (Exception ignore) {}
 
@@ -2593,21 +2592,30 @@ public class BossAttackController {
 	        sb.append(ctx.job).append(" 마스터 보너스: ATK 10%, HP 15%, 리젠+1000").append(NL);
 	    }
 	     */
-        // 가방현황 (91=일반, 92=나메, 93=헬)
+        // 가방현황 (91=일반, 92=나메, 93=헬/황금/플래티넘)
         {
-            int bagNormal = 0, bagNm = 0, bagHell = 0;
+            int bagNormal = 0, bagNm = 0, bagHell = 0, bagGold = 0, bagPlat = 0;
             if (bag != null) {
                 for (HashMap<String,Object> brow : bag) {
                     int bId = MiniGameUtil.parseIntSafe(Objects.toString(brow.get("ITEM_ID"), "0"));
                     int bQty = MiniGameUtil.parseIntSafe(Objects.toString(brow.get("TOTAL_QTY"), "0"));
+                    String gt = Objects.toString(brow.get("GAIN_TYPE"), "");
                     if (bId == 91) bagNormal += bQty;
-                    else if (bId == 92) bagNm   += bQty;
-                    else if (bId == 93) bagHell  += bQty;
+                    else if (bId == 92) bagNm += bQty;
+                    else if (bId == 93) {
+                        if ("DROP_OPEN_G".equals(gt)) bagGold += bQty;
+                        else if ("DROP_OPEN_P".equals(gt)) bagPlat += bQty;
+                        else bagHell += bQty;
+                    }
                 }
             }
             sb.append("가방현황[ 일반:").append(bagNormal)
               .append("/나메:").append(bagNm)
-              .append("/헬:").append(bagHell).append("]").append(NL);
+              .append("/헬:").append(bagHell);
+            if (bagGold > 0 || bagPlat > 0) {
+                sb.append(" (황금:").append(bagGold).append("/플래티넘:").append(bagPlat).append(")");
+            }
+            sb.append("]").append(NL);
         }
         sb.append("▶ 현재 타겟: ").append(targetName)
 	      .append(" (MON_NO=").append(u.targetMon).append(")").append(NL);

--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1455,9 +1455,8 @@ public class BossAttackController {
 	        SP totalSP, List<String> detail, List<String> itemSummary, boolean noSp,
 	        int[] goldRef, int[] platRef) {
 	    if (count <= 0) return;
-	    long top1Sp = getTop1SpCached();
-	    long spMax  = top1Sp > 0 ? Math.min(top1Sp / 100, 100_000_000_000L) : 5_000_000L;   // 1등의 1%, 최대 1000b
-	    long spMin  = Math.min(100_000_000_000L, spMax);                                      // 고정 100b (spMax 초과 방지)
+	    long spMin  = 100_000_000_000L; // 고정 1000b
+	    long spMax  = 100_000_000_000L; // 고정 1000b
 	    SP hellSpLocal = new SP(0, ""); // SP 합산용 (루프 후 1회 INSERT)
 	    // 황금/플래티넘 누적: 외부 ref 있으면 공유, 없으면 로컬
 	    boolean useRef = (goldRef != null && platRef != null);

--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -1456,8 +1456,8 @@ public class BossAttackController {
 	        int[] goldRef, int[] platRef) {
 	    if (count <= 0) return;
 	    long top1Sp = getTop1SpCached();
-	    long spMin  = top1Sp > 0 ? top1Sp * 3 / 1000 : 1_000_000L;                          // 1등의 0.3%
 	    long spMax  = top1Sp > 0 ? Math.min(top1Sp / 100, 100_000_000_000L) : 5_000_000L;   // 1등의 1%, 최대 1000b
+	    long spMin  = Math.min(100_000_000_000L, spMax);                                      // 고정 100b (spMax 초과 방지)
 	    SP hellSpLocal = new SP(0, ""); // SP 합산용 (루프 후 1회 INSERT)
 	    // 황금/플래티넘 누적: 외부 ref 있으면 공유, 없으면 로컬
 	    boolean useRef = (goldRef != null && platRef != null);

--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -265,16 +265,16 @@ public class BossAttackS3Controller {
             return userName + "님, 데스 상태입니다. 체력을 회복 후 공격 가능합니다.";
         }
 
-        // 대악마/마왕 감금 상태 체크
-        Long imprisonUntil = IMPRISONED_UNTIL.get(userName);
-        if (imprisonUntil != null) {
-            if (System.currentTimeMillis() < imprisonUntil) {
-                long remainSec = (imprisonUntil - System.currentTimeMillis()) / 1000;
-                long remMin = remainSec / 60, remSec = remainSec % 60;
-                return userName + "님, [감금스킬] 공격 불가 상태입니다. (" + remMin + "분 " + remSec + "초 남음)";
-            }
-            IMPRISONED_UNTIL.remove(userName);
-        }
+        // 대악마/마왕 감금 상태 체크 (임시 비활성화)
+        // Long imprisonUntil = IMPRISONED_UNTIL.get(userName);
+        // if (imprisonUntil != null) {
+        //     if (System.currentTimeMillis() < imprisonUntil) {
+        //         long remainSec = (imprisonUntil - System.currentTimeMillis()) / 1000;
+        //         long remMin = remainSec / 60, remSec = remainSec % 60;
+        //         return userName + "님, [감금스킬] 공격 불가 상태입니다. (" + remMin + "분 " + remSec + "초 남음)";
+        //     }
+        //     IMPRISONED_UNTIL.remove(userName);
+        // }
 
         // 보스 정보 조회 (전역, ROOM_NAME 없음)
         HashMap<String, Object> boss;
@@ -818,11 +818,10 @@ public class BossAttackS3Controller {
             } catch (Exception ignored) {}
         }
 
-        // 대악마/마왕 감금스킬 발동 (10% 확률)
-        if (("대악마".equals(bossDemonType) || "마왕".equals(bossDemonType)) && rand.nextInt(100) < IMPRISON_CHANCE_PCT) {
-            IMPRISONED_UNTIL.put(userName, System.currentTimeMillis() + IMPRISON_DURATION_MS);
-            // 감금 메시지는 아래 최종 msg 조립 후 추가
-        }
+        // 대악마/마왕 감금스킬 발동 (임시 비활성화)
+        // if (("대악마".equals(bossDemonType) || "마왕".equals(bossDemonType)) && rand.nextInt(100) < IMPRISON_CHANCE_PCT) {
+        //     IMPRISONED_UNTIL.put(userName, System.currentTimeMillis() + IMPRISON_DURATION_MS);
+        // }
 
         // DB 저장 (HP 업데이트 + 배틀 로그)
         // hp    : 낙관적 잠금 WHERE 절용 → DB 원본값 그대로 (double)
@@ -999,11 +998,11 @@ public class BossAttackS3Controller {
             msg.append(specialTimeMsg).append(NL);
         }
 
-        // 대악마/마왕 감금스킬 발동 메시지
-        if (IMPRISONED_UNTIL.containsKey(userName) &&
-                System.currentTimeMillis() < IMPRISONED_UNTIL.get(userName)) {
-            msg.append(NL).append("[감금스킬] ").append(userName).append("님이 5분간 공격 불가 상태가 됩니다!");
-        }
+        // 대악마/마왕 감금스킬 발동 메시지 (임시 비활성화)
+        // if (IMPRISONED_UNTIL.containsKey(userName) &&
+        //         System.currentTimeMillis() < IMPRISONED_UNTIL.get(userName)) {
+        //     msg.append(NL).append("[감금스킬] ").append(userName).append("님이 5분간 공격 불가 상태가 됩니다!");
+        // }
 
         return msg.toString().trim();
     }
@@ -1081,12 +1080,12 @@ public class BossAttackS3Controller {
             double rwDice = rand.nextDouble();
             String preRewardType = rwDice >= 0.80 ? "ITEM" : rwDice >= 0.40 ? "BOX" : "GP";
             bossMap.put("rewardType", preRewardType);
-            // 보스 타입 결정: 마왕 20%, 대악마 15%, 상급악마 65%
+            // 보스 타입 결정: 공격자 10명 이상일 때만 마왕(20%)/대악마(15%) 등장 가능
             double bossTypeDice = rand.nextDouble();
             String bossType;
-            if (bossTypeDice < 0.20) {
+            if (participantCount >= 10 && bossTypeDice < 0.20) {
                 bossType = "마왕";
-            } else if (bossTypeDice < 0.35) {
+            } else if (participantCount >= 10 && bossTypeDice < 0.35) {
                 bossType = "대악마";
             } else {
                 bossType = "상급악마";

--- a/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
@@ -200,6 +200,8 @@ public interface BotNewDAO {
     int upgradePendingHellBox(HashMap<String,Object> map);
     int confirmPendingHellBox(String userName);
     int decrementPendingHellBox(String userName);
+    List<HashMap<String,Object>> selectAllPendingHellBoxGrouped(String userName);
+    int confirmAllPendingHellBoxes(String userName);
 
     List<HashMap<String,Object>> selectActiveSetBonuses(@Param("userName") String userName);
 

--- a/src/main/java/my/prac/core/prjbot/service/BotNewService.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotNewService.java
@@ -158,6 +158,8 @@ public interface BotNewService {
     void upgradePendingHellBox(HashMap<String,Object> map);
     void confirmPendingHellBox(String userName);
     void decrementPendingHellBox(String userName);
+    List<HashMap<String,Object>> selectAllPendingHellBoxGrouped(String userName);
+    void confirmAllPendingHellBoxes(String userName);
 
     List<HashMap<String,Object>> selectActiveSetBonuses(String userName);
 

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
@@ -508,6 +508,16 @@ public class BotNewServiceImpl implements BotNewService {
     }
 
     @Override
+    public List<HashMap<String,Object>> selectAllPendingHellBoxGrouped(String userName) {
+        return botNewDAO.selectAllPendingHellBoxGrouped(userName);
+    }
+
+    @Override
+    public void confirmAllPendingHellBoxes(String userName) {
+        botNewDAO.confirmAllPendingHellBoxes(userName);
+    }
+
+    @Override
     public List<HashMap<String,Object>> selectActiveSetBonuses(String userName) {
         return botNewDAO.selectActiveSetBonuses(userName);
     }

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -1640,6 +1640,26 @@
 		     ) WHERE ROWNUM = 1
 		 )
 	</update>
+	<select id="selectAllPendingHellBoxGrouped" parameterType="String" resultType="hashmap">
+		/* selectAllPendingHellBoxGrouped: 유저의 pending 황금/플래티넘 전체 집계 */
+		SELECT GAIN_TYPE, SUM(QTY) AS QTY
+		  FROM TBOT_POINT_NEW_INVENTORY
+		 WHERE USER_NAME = #{userName}
+		   AND ITEM_ID   = 93
+		   AND GAIN_TYPE IN ('DROP_OPEN_G', 'DROP_OPEN_P')
+		   AND DEL_YN    = '0'
+		 GROUP BY GAIN_TYPE
+		 ORDER BY MIN(INSERT_DATE) ASC
+	</select>
+	<update id="confirmAllPendingHellBoxes" parameterType="String">
+		/* confirmAllPendingHellBoxes: 모든 pending 황금/플래티넘 일괄 소비 */
+		UPDATE TBOT_POINT_NEW_INVENTORY
+		   SET DEL_YN = '1'
+		 WHERE USER_NAME = #{userName}
+		   AND ITEM_ID   = 93
+		   AND GAIN_TYPE IN ('DROP_OPEN_G', 'DROP_OPEN_P')
+		   AND DEL_YN    = '0'
+	</update>
 	<select id="selectNightmareYn" parameterType="map" resultType="int">
 		/* selectNightmareYn */
 		SELECT NVL(NIGHTMARE_YN, '0') AS NIGHTMARE_YN


### PR DESCRIPTION
## Summary

- `/가방열기` 시 황금+플래티넘 pending 상자를 한 번에 모두 개봉 (기존: 타입별 1회씩 분리 호출)
- 가방현황(`/가방`)에 황금/플래티넘 pending 수량 별도 표시
- 헬상자 SP 1000b 고정 (min=max=1000b, 상위유저 SP 연동 제거)
- 대악마/마왕 보스는 공격자 10명 이상일 때만 등장
- 감금스킬(5분 공격불가) 임시 비활성화

## 변경 파일

- `BossAttackController.java` — openBag 일괄처리, attackInfo 가방현황, openHellBag SP 고정
- `BossAttackS3Controller.java` — 보스 타입 조건, 감금스킬 비활성화
- `BotNewMapper.xml` — selectAllPendingHellBoxGrouped, confirmAllPendingHellBoxes 추가
- `BotNewDAO.java` / `BotNewService.java` / `BotNewServiceImpl.java` — 신규 메서드 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T26pUx6SYhmE8m3EUAQPG7

---
_Generated by [Claude Code](https://claude.ai/code/session_01T26pUx6SYhmE8m3EUAQPG7)_