### PR TITLE
feat: 카운트업 보스(심연의 군주) 신규 구현 + ATK_MIN_RATE 버그 수정 + 홀짝 패턴 제거

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -2727,7 +2727,7 @@ public class BossAttackController {
                         hellRegen      += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("HP_REGEN"),     "0")) * hQty;
                         hellCrit       += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("ATK_CRI"),      "0")) * hQty;
                         hellCritDmg    += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("CRI_DMG"),      "0")) * hQty;
-                        if (hId == 3003) hellAtkMinRate += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("ATK_MAX_RATE"), "0")) * hQty;
+                        if (hId == 3003) hellAtkMinRate += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("ATK_MIN_RATE"), "0")) * hQty;
                         else if (hId == 3004) hellAtkMaxRate += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("ATK_MAX_RATE"), "0")) * hQty;
                         hellHpMaxRate  += MiniGameUtil.parseIntSafe(Objects.toString(hrow.get("HP_MAX_RATE"),  "0")) * hQty;
                     }

--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -68,10 +68,10 @@ public class BossAttackS3Controller {
     /** 헬보스 보상 아이템 타입 */
     private static final String HELL_ITEM_TYPE = "BOSS_HELL";
 
-    /** 카운트업 보스: DB 저장값 / 표시 이름 / 2시간 윈도우 */
+    /** 카운트업 보스: DB 저장값 / 표시 이름 / 1시간 윈도우 */
     private static final String COUNTUP_BOSS_TYPE    = "카운트업";
     static final String COUNTUP_DISPLAY_NAME  = "심연의 군주"; // TODO: 이름 확정 후 수정
-    private static final long   COUNTUP_WINDOW_HOURS = 2;
+    private static final long   COUNTUP_WINDOW_HOURS = 1;
     /** 카운트업 보스 목표 HP (표시용, raw SP 단위) — 100b */
     private static final long   COUNTUP_TARGET_HP    = 10_000_000_000L;
 
@@ -384,11 +384,7 @@ public class BossAttackS3Controller {
             } catch (Exception ignored) {}
         }
 
-        // 홀수/짝수 패턴 시간대 체크 (카운트업 보스는 제외)
-        if (!isCountUp) {
-            String patternBlock = checkPattern(bossPattern);
-            if (!patternBlock.isEmpty()) return patternBlock;
-        }
+        // 홀수/짝수 패턴 시간대 체크 비활성화 (전 보스 공통)
 
         // 상급악마/대악마/마왕/카운트업: 스탯 상한 적용 (공격력 100%, 나머지 50%)
         boolean isMajorBoss = "상급악마".equals(bossDemonType) || "대악마".equals(bossDemonType) || "마왕".equals(bossDemonType) || isCountUp;
@@ -1262,7 +1258,9 @@ public class BossAttackS3Controller {
 
 
     // =========================================================
-    // 카운트업 보스 2시간 종료 보상: 전원에게 기여도 비례 GP + SP 지급
+    // 카운트업 보스 1시간 종료 보상: 개인 누적 데미지 기준 독립 지급
+    //   SP = myDamage × 300  (max 1c = 1,000,000,000,000 raw)
+    //   GP = myDamage ÷ 6,000,000  (max 10 GP)
     // =========================================================
     private String calcCountUpBossReward(String roomName, String bossStartDate, long totalAccumulated) {
         StringBuilder msg = new StringBuilder();
@@ -1282,28 +1280,16 @@ public class BossAttackS3Controller {
             return msg.toString();
         }
 
-        long totalScore = 0;
-        for (HashMap<String, Object> row : contributors)
-            totalScore += ((Number) row.get("SCORE")).longValue();
-
-        if (totalScore <= 0) totalScore = 1;
-
-        // 보상 풀: GP 20 고정, SP = 누적데미지 × 1000 (10b ~ 1000b 범위)
-        final double totalGpPool = 20.0;
-        final long totalSpPoolRaw = Math.max(1_000_000_000L, Math.min(100_000_000_000L, totalAccumulated * 1000L));
-
-        msg.append("누적 데미지: ").append(SP.fromSp(totalAccumulated))
-           .append(" / 참여자: ").append(contributors.size()).append("명").append(NL);
-        msg.append("보상 풀: ").append(SP.fromSp(totalSpPoolRaw)).append(" SP + ").append((int)totalGpPool).append(" GP (기여도 비례)").append(NL).append(NL);
+        msg.append("총 누적 데미지: ").append(SP.fromSp(totalAccumulated))
+           .append(" / 참여자: ").append(contributors.size()).append("명").append(NL).append(NL);
 
         for (HashMap<String, Object> row : contributors) {
-            String uName = Objects.toString(row.get("USER_NAME"), "");
-            long myScore = ((Number) row.get("SCORE")).longValue();
-            double ratio = (double) myScore / totalScore;
+            String uName   = Objects.toString(row.get("USER_NAME"), "");
+            long myDamage  = ((Number) row.get("SCORE")).longValue();
 
-            // SP 지급
-            long mySpRaw = (long)(totalSpPoolRaw * ratio);
-            if (mySpRaw < 10_000_000L) mySpRaw = 10_000_000L; // 최소 1000a
+            // SP: myDamage × 300, cap 1c (1,000,000,000,000 raw)
+            long mySpRaw = Math.min(1_000_000_000_000L, myDamage * 300L);
+            if (mySpRaw < 10_000_000L) mySpRaw = 10_000_000L;
             SP mySp = SP.fromSp(mySpRaw);
             try {
                 HashMap<String, Object> pr = new HashMap<>();
@@ -1315,9 +1301,10 @@ public class BossAttackS3Controller {
                 botNewService.insertPointRank(pr);
             } catch (Exception ignore) {}
 
-            // GP 지급
-            double myGp = Math.floor(totalGpPool * ratio * 100) / 100.0;
-            if (myGp < 0.01) myGp = 0.01;
+            // GP: myDamage ÷ 6,000,000, cap 10 GP
+            double myGp = Math.min(10.0, myDamage / 6_000_000.0);
+            if (myGp < 0.1) myGp = 0.1;
+            myGp = Math.floor(myGp * 100) / 100.0;
             try {
                 HashMap<String, Object> gp = new HashMap<>();
                 gp.put("userName", uName);
@@ -1327,9 +1314,12 @@ public class BossAttackS3Controller {
                 botNewService.insertGpRecord(gp);
             } catch (Exception ignore) {}
 
+            double gpBalance = 0;
+            try { gpBalance = botNewService.selectGpBalance(uName); } catch (Exception ignore) {}
+
             msg.append(uName).append(": +").append(mySp).append(" SP, +")
                .append(String.format("%.2f", myGp)).append(" GP")
-               .append(" (기여 ").append(String.format("%.1f", ratio * 100)).append("%)").append(NL);
+               .append(" (보유 ").append(String.format("%.2f", Math.floor(gpBalance * 100) / 100.0)).append(" GP)").append(NL);
         }
 
         return msg.toString();

--- a/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackS3Controller.java
@@ -68,6 +68,13 @@ public class BossAttackS3Controller {
     /** 헬보스 보상 아이템 타입 */
     private static final String HELL_ITEM_TYPE = "BOSS_HELL";
 
+    /** 카운트업 보스: DB 저장값 / 표시 이름 / 2시간 윈도우 */
+    private static final String COUNTUP_BOSS_TYPE    = "카운트업";
+    static final String COUNTUP_DISPLAY_NAME  = "심연의 군주"; // TODO: 이름 확정 후 수정
+    private static final long   COUNTUP_WINDOW_HOURS = 2;
+    /** 카운트업 보스 목표 HP (표시용, raw SP 단위) — 100b */
+    private static final long   COUNTUP_TARGET_HP    = 10_000_000_000L;
+
     // ── 대악마 감금스킬 ──
     private static final Map<String, Long> IMPRISONED_UNTIL   = new java.util.concurrent.ConcurrentHashMap<>();
     private static final int IMPRISON_DURATION_MS = 5 * 60 * 1000; // 5분
@@ -328,6 +335,9 @@ public class BossAttackS3Controller {
             return "보스 정보를 가져오는데 실패했습니다.";
         }
 
+        boolean isCountUp = COUNTUP_BOSS_TYPE.equals(bossDemonType);
+        String bossDisplayName = isCountUp ? COUNTUP_DISPLAY_NAME : bossDemonType;
+
         // 재생성 쿨타임 체크 (startDate가 미래면 아직 등장 전 → 패턴 체크 불필요)
         if (!bossStartDate.isEmpty()) {
             try {
@@ -340,7 +350,7 @@ public class BossAttackS3Controller {
                             : remainMin + "분";
                     StringBuilder sb = new StringBuilder();
                     sb.append(userName).append("님,").append(NL)
-                      .append("상급악마가 재정비 중입니다.").append(NL)
+                      .append(bossDisplayName).append("가 재정비 중입니다.").append(NL)
                       .append("등장까지 ").append(remainStr).append(" 남았습니다.");
                     try {
                         String lastReward = botS3Service.getLastKillRewardMsg();
@@ -353,12 +363,35 @@ public class BossAttackS3Controller {
             } catch (Exception ignored) {}
         }
 
-        // 홀수/짝수 패턴 시간대 체크 (보스가 등장한 이후에만 적용)
-        String patternBlock = checkPattern(bossPattern);
-        if (!patternBlock.isEmpty()) return patternBlock;
+        // 카운트업 보스: 2시간 윈도우 종료 여부 체크
+        if (isCountUp && !bossStartDate.isEmpty()) {
+            try {
+                LocalDateTime spawnTime = LocalDateTime.parse(bossStartDate, DateTimeFormatter.ofPattern("yyyyMMdd HHmmss"));
+                LocalDateTime closeTime = spawnTime.plusHours(COUNTUP_WINDOW_HOURS);
+                if (LocalDateTime.now().isAfter(closeTime)) {
+                    int closed = botS3Service.closeHellBoss(seq);
+                    if (closed > 0) {
+                        String rewardMsg = calcCountUpBossReward(roomName, bossStartDate, hp);
+                        botS3Service.saveLastKillMsg(rewardMsg);
+                        respawnHellBoss(bossStartDate);
+                        return "[" + COUNTUP_DISPLAY_NAME + "] ⌛ 2시간 윈도우가 종료되었습니다!" + NL
+                                + rewardMsg + NL + NL
+                                + "새로운 보스가 소환됩니다!";
+                    } else {
+                        return userName + "님, 보스가 이미 종료되었습니다.";
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
 
-        // 상급악마/대악마/마왕: 스탯 상한 적용 (공격력 100%, 나머지 50%)
-        boolean isMajorBoss = "상급악마".equals(bossDemonType) || "대악마".equals(bossDemonType) || "마왕".equals(bossDemonType);
+        // 홀수/짝수 패턴 시간대 체크 (카운트업 보스는 제외)
+        if (!isCountUp) {
+            String patternBlock = checkPattern(bossPattern);
+            if (!patternBlock.isEmpty()) return patternBlock;
+        }
+
+        // 상급악마/대악마/마왕/카운트업: 스탯 상한 적용 (공격력 100%, 나머지 50%)
+        boolean isMajorBoss = "상급악마".equals(bossDemonType) || "대악마".equals(bossDemonType) || "마왕".equals(bossDemonType) || isCountUp;
         if (isMajorBoss) {
             bossAtkRate   = Math.max(BOSS_ATK_RATE_MIN,   Math.min(50, bossAtkRate));
             bossAtkPower  = Math.max(BOSS_ATK_POWER_MIN,  Math.min(100, bossAtkPower));
@@ -718,11 +751,11 @@ public class BossAttackS3Controller {
             }
         }
 
-        // HP 차감 (1차)
+        // HP 차감 (1차) — 카운트업 보스는 HP가 올라가므로 kill 없음
         SP newHpSp = isEvade || totalDamage <= 0
                 ? SP.of(curHpNum, curHpExt)
                 : SP.of(curHpNum, curHpExt).subtract(SP.fromSp(totalDamage));
-        boolean isKill = SP.toBaseValue(newHpSp) <= 0;
+        boolean isKill = !isCountUp && SP.toBaseValue(newHpSp) <= 0;
         long newHp = isKill ? 0 : SP.toBaseValue(newHpSp);
 
         // 보스 반격 (유저 최대HP × bossAtkPower% 비례 데미지)
@@ -773,9 +806,11 @@ public class BossAttackS3Controller {
             int reflectPermille = getBossEnhanceVal(7005, qty7005); // 10=1.0%, 15=1.5%
             reflectDmg = Math.max(1, (int)Math.round(bossAtkApplied * reflectPermille / 1000.0));
             totalDamage += reflectDmg;
-            newHpSp = SP.of(curHpNum, curHpExt).subtract(SP.fromSp(totalDamage));
-            isKill = SP.toBaseValue(newHpSp) <= 0;
-            newHp = isKill ? 0 : SP.toBaseValue(newHpSp);
+            if (!isCountUp) {
+                newHpSp = SP.of(curHpNum, curHpExt).subtract(SP.fromSp(totalDamage));
+                isKill = SP.toBaseValue(newHpSp) <= 0;
+                newHp = isKill ? 0 : SP.toBaseValue(newHpSp);
+            }
             reflectMsg = "[가시갑옷] 반사 +" + reflectDmg + "!" + NL;
         }
 
@@ -808,29 +843,31 @@ public class BossAttackS3Controller {
         }
 
         // DB 저장 (HP 업데이트 + 배틀 로그)
-        // hp    : 낙관적 잠금 WHERE 절용 → DB 원본값 그대로 (double)
-        // newHp : SP 변환 결과 소수값 (예: 2.99832)
-        // newHpExt: SP 변환 결과 단위 (예: "b"), 없으면 null
-        double newHpDbVal = isKill ? 0.0 : newHpSp.getValue();
-        String newHpDbExt = isKill || newHpSp.getUnit().isEmpty() ? null : newHpSp.getUnit();
-        map.put("hp",       curHpNum);
-        map.put("newHp",    newHpDbVal);
-        map.put("newHpExt", newHpDbExt);
-        map.put("seq",          seq);
-        map.put("endYn",        isKill ? "1" : "0");
-        map.put("lv",           user.lv);
-        map.put("atkDmg",       totalDamage);
-        map.put("monDmg",       bossAtkApplied);
-        map.put("atkCritYn",    isCritical ? "1" : "0");
-        map.put("killYn",       isKill ? "1" : "0");
-        map.put("job",          ctx.job);
-        if (heavensPunishment)                   map.put("heavensPunishment", getBossEnhanceVal(7001, heaven7001Qty));
-        if (flag_boss_debuff)                    map.put("useDebuff", 1);
-        if (debuff1_start)                       map.put("debuff1_start", 1);
-        if (flag_boss_debuff1 && !debuff1_start) map.put("useDebuff1", 1);
+        map.put("seq",       seq);
+        map.put("lv",        user.lv);
+        map.put("atkDmg",    totalDamage);
+        map.put("monDmg",    bossAtkApplied);
+        map.put("atkCritYn", isCritical ? "1" : "0");
+        map.put("killYn",    isKill ? "1" : "0");
+        map.put("job",       ctx.job);
 
         try {
-            botS3Service.updateHellBossTx(map);
+            if (isCountUp) {
+                map.put("rawDmg", isEvade ? 0L : totalDamage);
+                botS3Service.updateHellBossCountUpTx(map);
+            } else {
+                double newHpDbVal = isKill ? 0.0 : newHpSp.getValue();
+                String newHpDbExt = isKill || newHpSp.getUnit().isEmpty() ? null : newHpSp.getUnit();
+                map.put("hp",       curHpNum);
+                map.put("newHp",    newHpDbVal);
+                map.put("newHpExt", newHpDbExt);
+                map.put("endYn",    isKill ? "1" : "0");
+                if (heavensPunishment)                   map.put("heavensPunishment", getBossEnhanceVal(7001, heaven7001Qty));
+                if (flag_boss_debuff)                    map.put("useDebuff", 1);
+                if (debuff1_start)                       map.put("debuff1_start", 1);
+                if (flag_boss_debuff1 && !debuff1_start) map.put("useDebuff1", 1);
+                botS3Service.updateHellBossTx(map);
+            }
         } catch (Exception e) {
             return "저장 중 오류가 발생했습니다.";
         }
@@ -858,9 +895,9 @@ public class BossAttackS3Controller {
             } catch (Exception ignore) {}
         }
 
-        // 공격 보상: 마왕은 GP, 그 외는 SP
+        // 공격 보상: 카운트업 보스는 즉시 보상 없음 (2시간 종료 시 일괄 지급)
         String spRewardMsg = "";
-        if (isMaWang && !isEvade && totalDamage > 0) {
+        if (!isCountUp && isMaWang && !isEvade && totalDamage > 0) {
             // 마왕 GP 보상: 0.02 ~ 0.40 GP (데미지 비례, 100만 대비)
             try {
                 double gpRatio = Math.min(1.0, totalDamage / 1_000_000.0);
@@ -879,7 +916,7 @@ public class BossAttackS3Controller {
             } catch (Exception e) {
                 // GP 지급 실패는 무시
             }
-        } else if (!isMaWang) {
+        } else if (!isCountUp && !isMaWang) {
             try {
                 long rawSpVal = totalDamage * 10000L;
                 boolean isGreatDemonSp = "대악마".equals(bossDemonType);
@@ -920,7 +957,7 @@ public class BossAttackS3Controller {
 
         // 결과 메시지
         StringBuilder msg = new StringBuilder();
-        msg.append(userName).append("님이 [").append(bossDemonType).append("]를 공격했습니다!").append(NL);
+        msg.append(userName).append("님이 [").append(bossDisplayName).append("]를 공격했습니다!").append(NL);
 
         if (!isEvade) {
             if (isMaWang) {
@@ -966,8 +1003,24 @@ public class BossAttackS3Controller {
 
         msg.append(NL);
         if (isKill) {
-            msg.append("✨").append(bossDemonType).append("를 처치했습니다!").append(NL).append(killMsg);
-            msg.append(NL).append("새로운 상급악마가 출현했습니다!").append(NL);
+            msg.append("✨").append(bossDisplayName).append("를 처치했습니다!").append(NL).append(killMsg);
+            msg.append(NL).append("새로운 보스가 출현했습니다!").append(NL);
+        } else if (isCountUp) {
+            long newAccumulated = hp + (isEvade ? 0L : totalDamage);
+            SP accSp = SP.fromSp(newAccumulated);
+            SP targetSp = SP.fromSp(maxHp > 0 ? maxHp : COUNTUP_TARGET_HP);
+            double accPct = maxHp > 0 ? newAccumulated * 100.0 / maxHp : 0;
+            msg.append("📈 누적 데미지: ").append(accSp)
+               .append(" / ").append(targetSp)
+               .append(" (").append(String.format("%.1f", accPct)).append("%)").append(NL);
+            try {
+                LocalDateTime spawnTime2 = LocalDateTime.parse(bossStartDate, DateTimeFormatter.ofPattern("yyyyMMdd HHmmss"));
+                long remainSecs = java.time.Duration.between(LocalDateTime.now(), spawnTime2.plusHours(COUNTUP_WINDOW_HOURS)).toSeconds();
+                if (remainSecs > 0) {
+                    msg.append("⏱ 종료까지: ").append(remainSecs / 60).append("분 ").append(remainSecs % 60).append("초").append(NL);
+                }
+            } catch (Exception ignored) {}
+            msg.append("💡 2시간 종료 시 기여도 비례 GP+SP 지급!").append(NL);
         } else {
             String curHpDisp = SP.fromSp(newHp).toString();
             String maxHpDisp = SP.fromSp(maxHp).toString();
@@ -1064,18 +1117,21 @@ public class BossAttackS3Controller {
             double rwDice = rand.nextDouble();
             String preRewardType = rwDice >= 0.80 ? "ITEM" : rwDice >= 0.40 ? "BOX" : "GP";
             bossMap.put("rewardType", preRewardType);
-            // 보스 타입 결정: 공격자 10명 이상일 때만 마왕(20%)/대악마(15%) 등장 가능
+            // 보스 타입 결정: 카운트업(15%) 우선, 이후 기존 비율
             double bossTypeDice = rand.nextDouble();
             String bossType;
-            if (participantCount >= 10 && bossTypeDice < 0.20) {
+            if (bossTypeDice < 0.15) {
+                bossType = COUNTUP_BOSS_TYPE;
+            } else if (participantCount >= 10 && bossTypeDice < 0.32) {
                 bossType = "마왕";
-            } else if (participantCount >= 10 && bossTypeDice < 0.35) {
+            } else if (participantCount >= 10 && bossTypeDice < 0.47) {
                 bossType = "대악마";
             } else {
                 bossType = "상급악마";
             }
-            boolean isGreatDemon = "대악마".equals(bossType);
-            boolean isDemonKing  = "마왕".equals(bossType);
+            boolean isGreatDemon  = "대악마".equals(bossType);
+            boolean isDemonKing   = "마왕".equals(bossType);
+            boolean isCountUpBoss = COUNTUP_BOSS_TYPE.equals(bossType);
             bossMap.put("bossType", bossType);
             if (isGreatDemon) {
                 // 대악마 HP: 1200a ~ 1500a 고정 범위
@@ -1095,11 +1151,18 @@ public class BossAttackS3Controller {
                 bossMap.put("defPower",    Math.min(100, (int) bossMap.get("defPower")    * 3));
                 bossMap.put("evadeRate",   Math.min(100, (int) bossMap.get("evadeRate")   * 3));
                 bossMap.put("critDefRate", Math.min(100, (int) bossMap.get("critDefRate") * 3));
+            } else if (isCountUpBoss) {
+                // 카운트업: MAX_HP = 목표 데미지 표시용, CUR_HP=0 으로 별도 INSERT
+                rawHp = COUNTUP_TARGET_HP;
             }
             SP hpSp = SP.fromSp(rawHp);
             bossMap.put("maxHp",    (long) hpSp.getValue());
             bossMap.put("maxHpExt", hpSp.getUnit().isEmpty() ? null : hpSp.getUnit());
-            botS3Service.insertHellBoss(bossMap);
+            if (isCountUpBoss) {
+                botS3Service.insertHellBossCountUp(bossMap);
+            } else {
+                botS3Service.insertHellBoss(bossMap);
+            }
         } catch (Exception e) {
             // 재생성 실패는 무시 (처치 결과 메시지에 영향 없음)
         }
@@ -1197,6 +1260,80 @@ public class BossAttackS3Controller {
         return "";
     }
 
+
+    // =========================================================
+    // 카운트업 보스 2시간 종료 보상: 전원에게 기여도 비례 GP + SP 지급
+    // =========================================================
+    private String calcCountUpBossReward(String roomName, String bossStartDate, long totalAccumulated) {
+        StringBuilder msg = new StringBuilder();
+        msg.append("[ ").append(COUNTUP_DISPLAY_NAME).append(" 종료 보상 ]").append(NL);
+
+        List<HashMap<String, Object>> contributors;
+        try {
+            HashMap<String, Object> q = new HashMap<>();
+            q.put("bossStartDate", bossStartDate);
+            contributors = botS3Service.selectHellTop3Contributors(q);
+        } catch (Exception e) {
+            contributors = new ArrayList<>();
+        }
+
+        if (contributors == null || contributors.isEmpty()) {
+            msg.append("참여자가 없어 보상이 지급되지 않았습니다.").append(NL);
+            return msg.toString();
+        }
+
+        long totalScore = 0;
+        for (HashMap<String, Object> row : contributors)
+            totalScore += ((Number) row.get("SCORE")).longValue();
+
+        if (totalScore <= 0) totalScore = 1;
+
+        // 보상 풀: GP 20 고정, SP = 누적데미지 × 1000 (10b ~ 1000b 범위)
+        final double totalGpPool = 20.0;
+        final long totalSpPoolRaw = Math.max(1_000_000_000L, Math.min(100_000_000_000L, totalAccumulated * 1000L));
+
+        msg.append("누적 데미지: ").append(SP.fromSp(totalAccumulated))
+           .append(" / 참여자: ").append(contributors.size()).append("명").append(NL);
+        msg.append("보상 풀: ").append(SP.fromSp(totalSpPoolRaw)).append(" SP + ").append((int)totalGpPool).append(" GP (기여도 비례)").append(NL).append(NL);
+
+        for (HashMap<String, Object> row : contributors) {
+            String uName = Objects.toString(row.get("USER_NAME"), "");
+            long myScore = ((Number) row.get("SCORE")).longValue();
+            double ratio = (double) myScore / totalScore;
+
+            // SP 지급
+            long mySpRaw = (long)(totalSpPoolRaw * ratio);
+            if (mySpRaw < 10_000_000L) mySpRaw = 10_000_000L; // 최소 1000a
+            SP mySp = SP.fromSp(mySpRaw);
+            try {
+                HashMap<String, Object> pr = new HashMap<>();
+                pr.put("userName", uName);
+                pr.put("roomName", roomName);
+                pr.put("score",    mySp.getValue());
+                pr.put("scoreExt", mySp.getUnit());
+                pr.put("cmd",      "COUNTUP_BOSS_REWARD");
+                botNewService.insertPointRank(pr);
+            } catch (Exception ignore) {}
+
+            // GP 지급
+            double myGp = Math.floor(totalGpPool * ratio * 100) / 100.0;
+            if (myGp < 0.01) myGp = 0.01;
+            try {
+                HashMap<String, Object> gp = new HashMap<>();
+                gp.put("userName", uName);
+                gp.put("roomName", roomName);
+                gp.put("score",    myGp);
+                gp.put("cmd",      "COUNTUP_BOSS_REWARD_GP");
+                botNewService.insertGpRecord(gp);
+            } catch (Exception ignore) {}
+
+            msg.append(uName).append(": +").append(mySp).append(" SP, +")
+               .append(String.format("%.2f", myGp)).append(" GP")
+               .append(" (기여 ").append(String.format("%.1f", ratio * 100)).append("%)").append(NL);
+        }
+
+        return msg.toString();
+    }
 
     // =========================================================
     // 보상: 2% 이상 데미지 기여자 중 등확률 랜덤 지급

--- a/src/main/java/my/prac/core/prjbot/dao/BotS3DAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotS3DAO.java
@@ -50,4 +50,13 @@ public interface BotS3DAO {
 	/** [헬보스] 현재 보스 세션 최근 공격 로그 (TOP50) */
 	List<HashMap<String, Object>> selectHellBossRecentLog(HashMap<String, Object> map);
 
+	/** [카운트업 보스] HP 원자적 누적 */
+	int updateHellBossCountUpAdd(HashMap<String, Object> map);
+
+	/** [카운트업 보스] 종료 (END_YN=1) */
+	int closeHellBoss(HashMap<String, Object> map);
+
+	/** [카운트업 보스] 새 인스턴스 생성 (CUR_HP=0) */
+	int insertHellBossCountUp(HashMap<String, Object> map);
+
 }

--- a/src/main/java/my/prac/core/prjbot/service/BotS3Service.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotS3Service.java
@@ -41,4 +41,13 @@ public interface BotS3Service {
 	/** [헬보스] 현재 보스 세션 최근 공격 로그 (TOP50) */
 	List<HashMap<String, Object>> selectHellBossRecentLog(HashMap<String, Object> map);
 
+	/** [카운트업 보스] HP 누적 + 공격 로그 (트랜잭션) */
+	void updateHellBossCountUpTx(HashMap<String, Object> map) throws Exception;
+
+	/** [카운트업 보스] 종료 (END_YN=1). 성공 시 1, 이미 종료된 경우 0 반환 */
+	int closeHellBoss(int seq) throws Exception;
+
+	/** [카운트업 보스] 새 인스턴스 생성 (CUR_HP=0) */
+	void insertHellBossCountUp(HashMap<String, Object> map) throws Exception;
+
 }

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotS3ServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotS3ServiceImpl.java
@@ -78,6 +78,26 @@ public class BotS3ServiceImpl implements BotS3Service {
 	}
 
 	@Override
+	public void updateHellBossCountUpTx(HashMap<String, Object> map) throws Exception {
+		botS3DAO.updateHellBossCountUpAdd(map);
+		botS3DAO.insertHellBattleLog(map);
+	}
+
+	@Override
+	public int closeHellBoss(int seq) throws Exception {
+		HashMap<String, Object> p = new HashMap<>();
+		p.put("seq", seq);
+		return botS3DAO.closeHellBoss(p);
+	}
+
+	@Override
+	public void insertHellBossCountUp(HashMap<String, Object> map) throws Exception {
+		if (botS3DAO.insertHellBossCountUp(map) < 1) {
+			throw new Exception("카운트업 보스 생성 실패");
+		}
+	}
+
+	@Override
 	public void saveLastKillMsg(String msg) {
 		CACHED_KILL_MSG = (msg == null ? "" : msg.trim());
 	}

--- a/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotS3Mapper.xml
@@ -366,4 +366,76 @@
 	     WHERE ROWNUM &lt;= 200
 	</select>
 
+	<!-- =====================================================
+	     [카운트업 보스] HP 원자적 누적 (CUR_HP + dmg, 낙관적 잠금 없음)
+	     ===================================================== -->
+	<update id="updateHellBossCountUpAdd" parameterType="HashMap">
+		UPDATE TBOT_POINT_NEW_BOSS
+		   SET CUR_HP    = CUR_HP + #{rawDmg, jdbcType=NUMERIC}
+		     , PROC_DATE = SYSDATE
+		 WHERE SEQ    = #{seq, jdbcType=NUMERIC}
+		   AND END_YN = '0'
+	</update>
+
+	<!-- =====================================================
+	     [카운트업 보스] 종료 처리 (END_YN=1)
+	     ===================================================== -->
+	<update id="closeHellBoss" parameterType="HashMap">
+		UPDATE TBOT_POINT_NEW_BOSS
+		   SET END_YN    = '1'
+		     , PROC_DATE = SYSDATE
+		 WHERE SEQ    = #{seq, jdbcType=NUMERIC}
+		   AND END_YN = '0'
+	</update>
+
+	<!-- =====================================================
+	     [카운트업 보스] 새 인스턴스 생성 (CUR_HP=0으로 시작)
+	     ===================================================== -->
+	<insert id="insertHellBossCountUp" parameterType="HashMap">
+		INSERT INTO TBOT_POINT_NEW_BOSS
+		    (SEQ
+		    ,INSERT_DATE
+		    ,END_YN
+		    ,ATK_RATE
+		    ,ATK_POWER
+		    ,DEF_RATE
+		    ,DEF_POWER
+		    ,EVADE_RATE
+		    ,CRIT_DEF_RATE
+		    ,DEBUFF
+		    ,DEBUFF1
+		    ,DEBUFF2
+		    ,REWARD
+		    ,MAX_HP
+		    ,MAX_HP_EXT
+		    ,CUR_HP
+		    ,CUR_HP_EXT
+		    ,HIDE_RULE
+		    ,PATTERN
+		    ,REWARD_TYPE
+		    ,BOSS_TYPE)
+		SELECT NVL(MAX(SEQ), 0) + 1
+		      ,TO_DATE(#{startDate, jdbcType=VARCHAR},'yyyy-mm-dd hh24:mi:ss')
+		      ,'0'
+		      ,#{atkRate,     jdbcType=NUMERIC}
+		      ,#{atkPower,    jdbcType=NUMERIC}
+		      ,#{defRate,     jdbcType=NUMERIC}
+		      ,#{defPower,    jdbcType=NUMERIC}
+		      ,#{evadeRate,   jdbcType=NUMERIC}
+		      ,#{critDefRate, jdbcType=NUMERIC}
+		      ,0
+		      ,0
+		      ,0
+		      ,0
+		      ,#{maxHp,       jdbcType=NUMERIC}
+		      ,#{maxHpExt,    jdbcType=VARCHAR}
+		      ,0
+		      ,null
+		      ,#{hideRule,    jdbcType=VARCHAR}
+		      ,'없음'
+		      ,#{rewardType,  jdbcType=VARCHAR}
+		      ,'카운트업'
+		  FROM TBOT_POINT_NEW_BOSS
+	</insert>
+
 </mapper>


### PR DESCRIPTION
## Summary

- **버그 수정**: 지옥각인 최소공격력%(item 3003) 수치 표시 오류 — `ATK_MAX_RATE` → `ATK_MIN_RATE` 컬럼 오독 수정
- **신규 보스**: 카운트업 방식의 헬보스 "심연의 군주" 구현 (`BOSS_TYPE='카운트업'`)
- **전 헬보스**: 홀수/짝수 시간대 패턴 체크 비활성화

## 카운트업 보스 스펙

| 항목 | 내용 |
|-----|------|
| 테이블 | 기존 `TBOT_POINT_NEW_BOSS` 공용 재사용 (`BOSS_TYPE='카운트업'`) |
| HP 방식 | `CUR_HP=0` 시작, 공격마다 데미지 누적 (카운트업) |
| 데미지 배율 | 마왕과 동일 ×10 |
| 보스 반격 | 없음 (허수아비) |
| 패턴 제한 | 없음 (홀짝 시간대 무관) |
| 윈도우 | **1시간** (등장 후 1시간 경과 시 첫 공격으로 자동 종료) |
| 보상 | 개인 누적 데미지 기준 독립 지급 |
| SP 공식 | `myDamage × 300`, max **1c** |
| GP 공식 | `myDamage ÷ 6,000,000`, max **10 GP** |
| 재생성 확률 | 카운트업 15% / 마왕 17% / 대악마 15% / 상급악마 53% |
| 표시명 상수 | `COUNTUP_DISPLAY_NAME` (1줄 수정으로 이름 변경 가능) |

## 보상 실수령 예시 (쿨 70초, 1시간 풀참여 51회)
- SP: 51,000,000 × 300 = **153b SP**
- GP: 51,000,000 ÷ 6,000,000 = **8.5 GP**

## Test plan

- [ ] 카운트업 보스 등장 시 `BOSS_TYPE='카운트업'`, `CUR_HP=0` 확인
- [ ] 공격 시 `CUR_HP` 누적 증가, 보스 반격 없음 확인
- [ ] 1시간 경과 후 공격 시 자동 종료 + 보상 지급 메시지 확인
- [ ] SP/GP 지급 금액 공식 검증
- [ ] 이후 신규 보스 재생성 확인
- [ ] 가방(attackinfo) 지옥각인 최소공격력% 수치 정상 표시 확인
- [ ] 상급악마/대악마/마왕 홀짝 시간 무관하게 공격 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T26pUx6SYhmE8m3EUAQPG7

---
_Generated by [Claude Code](https://claude.ai/code/session_01T26pUx6SYhmE8m3EUAQPG7)_