### PR TITLE
feat: 매크로 탐지 로직 개선

### DIFF
--- a/src/main/java/my/prac/api/loa/controller/BossAttackController.java
+++ b/src/main/java/my/prac/api/loa/controller/BossAttackController.java
@@ -4783,21 +4783,32 @@ public class BossAttackController {
 		if ("람쥐봇 문의방".equals(s.roomName) && !s.master)
 			return "문의방에서는 불가능합니다.";
 
-		// 매크로 잠금 체크 (임시 비활성화)
-		/*
+		// 매크로 탐지 통합 체크 (시간당 20회+ 시 신규잠금/차단)
 		try {
-			HashMap<String,Object> macroLock = botNewService.selectMacroLock(s.userName);
-			if (macroLock != null) {
-				String code = Objects.toString(macroLock.get("CODE"), "");
-				int recentWarn = botNewService.countMacroDetectLogLastHour(s.userName);
-				try { botNewService.insertMacroDetectLog(s.userName, code); } catch (Exception ignore) {}
-				if (recentWarn == 0) {
+			int hourlyCnt = botNewService.selectHourlyRealAttackCount(s.userName);
+			if (hourlyCnt >= 20) {
+				HashMap<String,Object> recent = botNewService.selectMacroDetectRecentHour(s.userName);
+				if (recent == null) {
+					// 1시간 내 이력 없음 → 신규 잠금
+					String code = generateMacroCode();
+					botNewService.insertMacroLock(s.userName, code);
 					return s.userName + "님, 비정상 패턴이 감지되었습니다."+NL+"/매크로아님 " + code + " 를 입력하세요.";
+				} else {
+					String lockedYn = Objects.toString(recent.get("LOCKED_YN"), "0");
+					if ("1".equals(lockedYn)) {
+						// 잠금 중 → 로그 적재 + 경고(1시간 1회)
+						String code = Objects.toString(recent.get("CODE"), "");
+						int recentWarn = botNewService.countMacroDetectLogLastHour(s.userName);
+						try { botNewService.insertMacroDetectLog(s.userName, code); } catch (Exception ig) {}
+						if (recentWarn == 0) {
+							return s.userName + "님, 비정상 패턴이 감지되었습니다."+NL+"/매크로아님 " + code + " 를 입력하세요.";
+						}
+						return "";
+					}
+					// LOCKED_YN=0: 최근 해제 → 유예 허용
 				}
-				return "";
 			}
 		} catch (Exception ignore) {}
-		*/
 		s.param1 = Objects.toString(s.map.get("param1"), "");
 		return null;
 	}
@@ -5975,21 +5986,6 @@ public class BossAttackController {
 			msg += NL + ALL_SEE_STR + NL + detailOut.toString();
 		}
 
-		// 매크로 탐지: 실공격(exp>0) 기록 시 시간당 횟수 체크 (임시 비활성화)
-		/*
-		try {
-			if (s.res != null && s.res.gainExp > 0) {
-				int hourlyCnt = botNewService.selectHourlyRealAttackCount(s.userName);
-				if (hourlyCnt >= 20) {
-					HashMap<String,Object> existLock = botNewService.selectMacroLock(s.userName);
-					if (existLock == null) {
-						String code = generateMacroCode();
-						botNewService.insertMacroLock(s.userName, code);
-					}
-				}
-			}
-		} catch (Exception ignore) {}
-		*/
 
 		return msg;
 	}

--- a/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
+++ b/src/main/java/my/prac/core/prjbot/dao/BotNewDAO.java
@@ -336,7 +336,7 @@ public interface BotNewDAO {
 
     // ── 매크로 탐지 ───────────────────────────────────────────────────────────
     int selectHourlyRealAttackCount(String userName);
-    HashMap<String,Object> selectMacroLock(String userName);
+    HashMap<String,Object> selectMacroDetectRecentHour(String userName);
     int insertMacroLock(HashMap<String,Object> param);
     int releaseMacroLock(HashMap<String,Object> param);
     int countMacroDetectLogLastHour(String userName);

--- a/src/main/java/my/prac/core/prjbot/service/BotNewService.java
+++ b/src/main/java/my/prac/core/prjbot/service/BotNewService.java
@@ -281,7 +281,7 @@ public interface BotNewService {
 
     // ── 매크로 탐지 ───────────────────────────────────────────────────────────
     int selectHourlyRealAttackCount(String userName);
-    HashMap<String,Object> selectMacroLock(String userName);
+    HashMap<String,Object> selectMacroDetectRecentHour(String userName);
     int insertMacroLock(String userName, String code);
     int releaseMacroLock(String userName, String code);
     int countMacroDetectLogLastHour(String userName);

--- a/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
+++ b/src/main/java/my/prac/core/prjbot/service/impl/BotNewServiceImpl.java
@@ -1005,8 +1005,8 @@ public class BotNewServiceImpl implements BotNewService {
     }
 
     @Override
-    public HashMap<String,Object> selectMacroLock(String userName) {
-        return botNewDAO.selectMacroLock(userName);
+    public HashMap<String,Object> selectMacroDetectRecentHour(String userName) {
+        return botNewDAO.selectMacroDetectRecentHour(userName);
     }
 
     @Override

--- a/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
+++ b/src/main/resources/mybatis/mapper2.0/BotNewMapper.xml
@@ -2670,34 +2670,35 @@
            AND INSERT_DATE &lt;  TRUNC(SYSDATE, 'HH24') + 1/24
     </select>
 
-    <!-- 매크로 잠금 정보 조회 -->
-    <select id="selectMacroLock" parameterType="String" resultType="hashmap">
-        /* selectMacroLock */
-        SELECT USER_NAME, CODE, LOCKED_YN, LOCK_DATE
+    <!-- 1시간 내 매크로 등록/해제 이력 조회 (신규 잠금 여부 판단용) -->
+    <select id="selectMacroDetectRecentHour" parameterType="String" resultType="hashmap">
+        /* selectMacroDetectRecentHour */
+        SELECT USER_NAME, CODE, LOCKED_YN, LOCK_DATE, UNLOCK_DATE
           FROM TBOT_MACRO_DETECT
          WHERE USER_NAME = #{userName}
-           AND LOCKED_YN = '1'
+           AND (LOCK_DATE >= SYSDATE - 1/24
+                OR (UNLOCK_DATE IS NOT NULL AND UNLOCK_DATE >= SYSDATE - 1/24))
     </select>
 
-    <!-- 매크로 잠금 INSERT (중복 시 무시) -->
+    <!-- 매크로 신규 잠금 MERGE (이미 잠금이 아닌 경우에만 갱신) -->
     <insert id="insertMacroLock" parameterType="hashmap">
         /* insertMacroLock */
         MERGE INTO TBOT_MACRO_DETECT T
         USING (SELECT #{userName} AS UN, #{code} AS CD FROM DUAL) S
            ON (T.USER_NAME = S.UN)
         WHEN NOT MATCHED THEN
-            INSERT (USER_NAME, CODE, LOCKED_YN, LOCK_DATE)
-            VALUES (S.UN, S.CD, '1', SYSDATE)
+            INSERT (USER_NAME, CODE, LOCKED_YN, LOCK_DATE, UNLOCK_DATE)
+            VALUES (S.UN, S.CD, '1', SYSDATE, NULL)
         WHEN MATCHED THEN
-            UPDATE SET T.CODE = S.CD, T.LOCKED_YN = '1', T.LOCK_DATE = SYSDATE
+            UPDATE SET T.CODE = S.CD, T.LOCKED_YN = '1', T.LOCK_DATE = SYSDATE, T.UNLOCK_DATE = NULL
              WHERE T.LOCKED_YN != '1'
     </insert>
 
-    <!-- 매크로 잠금 해제 (코드 일치 시) -->
+    <!-- 매크로 잠금 해제: LOCKED_YN=0 + UNLOCK_DATE 기록 -->
     <update id="releaseMacroLock" parameterType="hashmap">
         /* releaseMacroLock */
         UPDATE TBOT_MACRO_DETECT
-           SET LOCKED_YN = '0'
+           SET LOCKED_YN = '0', UNLOCK_DATE = SYSDATE
          WHERE USER_NAME = #{userName}
            AND CODE      = #{code}
            AND LOCKED_YN = '1'


### PR DESCRIPTION
- TBOT_MACRO_DETECT에 UNLOCK_DATE 컬럼 추가
- 1시간 내 등록/해제 이력 기반 신규 잠금 판단 (selectMacroDetectRecentHour)
- 이력 없음 → 신규 잠금 INSERT + 인증문구 차단
- 이력 있고 잠금 중 → 로그 적재 + 경고(1시간 1회) 차단
- 이력 있고 해제됨(LOCKED_YN=0) → 유예, 공격 허용
- 잠금 해제 시 UNLOCK_DATE 기록 (releaseMacroLock)
- persistAndAchv 매크로 블록 제거 (preCheck 통합)